### PR TITLE
feat(status): add hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ local neogit = require("neogit")
 
 neogit.setup {
   disable_signs = false,
+  disable_hint = false,
   disable_context_highlighting = false,
   disable_commit_confirmation = false,
   auto_refresh = true,
@@ -202,6 +203,9 @@ You can override them to fit your colorscheme by creating a `syntax/NeogitStatus
 ### Disabling Contextual Highlighting
 
 Set `disable_context_highlighting = true` in your call to [`setup`](#configuration) to disable context highlighting altogether.
+
+## Disabling Hint
+Set `disable_hint = true` in your call to [`setup`](#configuration) to hide hints on top of the panel.
 
 ## Disabling Commit Confirmation
 

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 M.values = {
+  disable_hint = false,
   disable_context_highlighting = false,
   disable_signs = false,
   disable_commit_confirmation = false,

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -112,8 +112,10 @@ local function draw_buffer()
   M.status_buffer:clear_sign_group('fold_markers')
 
   local output = LineBuffer.new()
-  output:append("Hint: [<tab>] toggle diff | [s]tage | [u]nstage | [x] discard | [c]ommit | [?] more help")
-  output:append("")
+  if not config.values.disable_hint then
+    output:append("Hint: [<tab>] toggle diff | [s]tage | [u]nstage | [x] discard | [c]ommit | [?] more help")
+    output:append("")
+  end
   output:append(string.format("Head: %s %s", M.repo.head.branch, M.repo.head.commit_message or '(no commits)'))
   if M.repo.upstream.branch then
     output:append(string.format("Push: %s %s", M.repo.upstream.branch, M.repo.upstream.commit_message or '(no commits)'))


### PR DESCRIPTION
## Preface
As a beginner I feel that it would be convenient to have the common keymap displayed all the time, otherwise I have to keep looking at the help file until I can memorize them.

## Screenshots

| Before | After |
 |--|--|
|![image](https://user-images.githubusercontent.com/23183656/136401977-7acfb319-7c3e-498c-95ec-309bf2297123.png)|![image](https://user-images.githubusercontent.com/23183656/136401759-e85d1823-3fc2-4bcf-bb56-b59fc1be3a66.png)|