### PR TITLE
feat(status/discard): improve prompt copywriting

### DIFF
--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -663,7 +663,7 @@ local discard = function()
   end
   M.current_operation = "discard"
 
-  if not input.get_confirmation("Do you really want to do this?", {
+  if not input.get_confirmation("Discard '"..item.name.."' ?", {
     values = { "&Yes", "&No" },
     default = 2
   }) then


### PR DESCRIPTION
## Preface
Currently, the prompt for discarding changes is too generic and thus not very helpful for user to confirm that they've chose the correct file to discard.

## Screenshot
|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/23183656/138027019-c81cab34-11f8-4943-962e-ca539b79537b.png)|![image](https://user-images.githubusercontent.com/23183656/138026956-69febeee-d55f-4097-b3b7-949891c5d38e.png)|