### PR TITLE
fix(status): Highlights for commit SHA's longer than 7 chars.

### DIFF
--- a/syntax/NeogitStatus.vim
+++ b/syntax/NeogitStatus.vim
@@ -2,7 +2,7 @@ if exists("b:current_syntax")
   finish
 endif
 
-syn match NeogitObjectId /^[a-z0-9]\{7} /
+syn match NeogitObjectId /^[a-z0-9]\{7,}\>/
 syn match NeogitCommitMessage /.*/ contained
 syn match NeogitBranch /\S\+/ contained nextgroup=NeogitCommitMessage
 syn match NeogitRemote /\S\+/ contained nextgroup=NeogitCommitMessage


### PR DESCRIPTION
In big repos listing many commits, git will use more than 7 chars from the commit SHA to ensure the commits are unique.