### PR TITLE
Disable editing when initially opening NeogitStatus

### DIFF
--- a/lua/neogit/lib/git/push.lua
+++ b/lua/neogit/lib/git/push.lua
@@ -17,7 +17,7 @@ local function update_unmerged(state)
     return
   end
 
-  local result = cli.log.oneline.for_range("@{upstream}..").show_popup(false).call(true, true):trim().stdout
+  local result = cli.log.oneline.for_range("@{upstream}..").show_popup(false).call():trim().stdout
 
   state.unmerged.items = util.filter_map(result, function(x)
     if x == "" then


### PR DESCRIPTION
I stumbled upon this when I opened Neogit today and found through bisection that `45c1ef6e2c89920f0cca` introduced what seems like a bug to me.

When I run `:NeogitStatus<cr>` my cursor is in insert-mode, which shouldn't ever be possible in a readonly buffer. What I've done in the commit, fixes the issue, but I have no idea if it's the correct way to do it. From what I can tell, the first parameter to call is `verbose`, and the second one is unused after the change mentioned above.

I'll gladly take any suggestions