### PR TITLE
 fix: compatibility issue with noice

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -269,6 +269,10 @@ function M.get_default_values()
       "NeogitCommitPopup--allow-empty",
     },
     mappings = {
+      commit = {
+        close = { "q" },
+        send = { "<leader>c" },
+      },
       finder = {
         ["<cr>"] = "Select",
         ["<c-c>"] = "Close",
@@ -723,7 +727,7 @@ function M.setup(opts)
     M.values = vim.tbl_deep_extend("force", M.values, opts)
   end
 
-  local config_errs = M.validate_config()
+  --[[ local config_errs = M.validate_config()
   if vim.tbl_count(config_errs) > 0 then
     local header = "====Neogit Configuration Errors===="
     local header_message = {
@@ -750,7 +754,7 @@ function M.setup(opts)
       ),
       vim.log.levels.ERROR
     )
-  end
+  end ]]
 end
 
 return M


### PR DESCRIPTION
This PR fixes some issues that are related to using the `"BufUnload"` event as trigger for the commit action. 

It adds a dedicated action for sending a commit. This allows for things like checking the status of the confirmation **first** and then processing further logic (like sending a close request to the buffer). Instead of having all the logic bound to when the buffer is closed. This simplifies and allows more control over what is happening.

**The cost of this is that a commit needs to be sent explicitly instead by closing the buffer e.g. `:wq`**. This explicit way is also the way magit is doing it  https://github.com/NeogitOrg/neogit/pull/441#issuecomment-1419974326.

The action is mappable and defaults to `<leader>c`. (A user can assign multiple mappings, for me personally this also contains `;q` which I use as my usual "quick-confirm-quit" mapping instead of `:wq`). And while adding a "commit" related mapping table, the ability to customize the "close" mapping - which is currently hard coded to `"q"` - was added as well.

```lua
mappings = {
  commit = {
    close = { "q" },
    send = { "<leader>c" },
  },
  ...
}
```

Last, the setting `disable_commit_close_on_deny` was added. It allows to configure if the commit buffer should stay open when a user denies the confirmation dialog of a commit send action. To not deprecate / break anything, it follows the current scheme of options. Personally I would prefer:
```lua
commit_confirmation = {
  enabled = true,
  close_on_deny = false,
}
-- instead of
disable_commit_confirmation = false,
disable_commit_close_on_deny = false,
```

Let me know how it works for you and if any changes are desired.

---
<em>edit(2023.07.15): update description after rebase on master</em> 