### PR TITLE
Allow a diff to be shown for deleted files

### DIFF
--- a/lua/neogit/lib/git/diff.lua
+++ b/lua/neogit/lib/git/diff.lua
@@ -76,7 +76,7 @@ local function build_kind(header)
   elseif header_count == 4 then
     kind = "modified"
   elseif header_count == 5 then
-    kind = header[2]:match("(.*) mode %d+")
+    kind = header[2]:match("(.*) mode %d+") or header[3]:match("(.*) mode %d+")
   else
     logger.debug(vim.inspect(header))
   end


### PR DESCRIPTION
I'm not sure the reason for preventing diffs for `D` and `F`. I went back through the git-history for this repo and they seem to have been in place for years, but if I remove them... it just works fine with no issues that I can see. Works for both staged/unstaged deleted files.

![Screenshot 2023-03-06 at 11 19 33](https://user-images.githubusercontent.com/7228095/223082585-5118a8c4-a7e5-4088-9517-2b90906b325d.png)
