### PR TITLE
docs: add installation instructions for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ require `nvim-lua/plenary.nvim` using your plugin manager of choice, before requ
 | Plugin Manager                                       | Command                                                                        |
 |------------------------------------------------------|--------------------------------------------------------------------------------|
 | [Packer](https://github.com/wbthomason/packer.nvim)  | `use { 'TimUntersberger/neogit', requires = 'nvim-lua/plenary.nvim' }`         |
+| [Lazy](https://github.com/folke/lazy.nvim)           | `{ 'TimUntersberger/neogit', dependencies = 'nvim-lua/plenary.nvim' }`         | 
 | [Vim-plug](https://github.com/junegunn/vim-plug)     | `Plug 'TimUntersberger/neogit'`                                                |
 | [NeoBundle](https://github.com/Shougo/neobundle.vim) | `NeoBundle 'TimUntersberger/neogit'`                                           |
 | [Vundle](https://github.com/VundleVim/Vundle.vim)    | `Bundle 'TimUntersberger/neogit'`                                              |


### PR DESCRIPTION
Added instructions in the README for how to install Neogit with Lazy.nvim as a package manager. 