### PR TITLE
Use default vim notify icons when disable_builtin_notifications are true

### DIFF
--- a/lua/neogit/lib/notification.lua
+++ b/lua/neogit/lib/notification.lua
@@ -9,7 +9,7 @@ local function create(message, level, delay)
   end
 
   if config.values.disable_builtin_notifications then
-    vim.notify(message, level, { title = "Neogit", icon = "󰊢" })
+    vim.notify(message, level, { title = "Neogit" })
     return nil
   end
 


### PR DESCRIPTION
Not every font has a nerd font 3.0 patch yet. I suggest to use default icons.

This is how it looks with nvim-notify:
![grafik](https://github.com/TimUntersberger/neogit/assets/65787013/ead999f1-d0f2-4196-9a41-35f5eed9d7bb)

Without notify visualization like noice or nvim-notify the icon isn't shown anyway? At least i didn't find it.

@aleprovencio what do you think?
