### PR TITLE
wip: Keep the commit dialog open after exit

### DIFF
--- a/lua/neogit/buffers/commit_editor/init.lua
+++ b/lua/neogit/buffers/commit_editor/init.lua
@@ -55,6 +55,15 @@ function M:open()
               vim.cmd("silent w!")
             end)
           end
+        else
+          -- Check if the buffer is modified, and confirm exit if so
+          vim.api.nvim_buf_call(o.buf, function()
+            if vim.opt.modified:get() then
+              if not input.get_confirmation("Discard this commit?") then
+                -- Cancel the BufUnload here?
+              end
+            end
+          end)
         end
 
         if self.on_unload then


### PR DESCRIPTION
Here's where I got last night working on #552, thought I may as well put it out there. Ideally we stop the buffer from closing at this point, but I don't know if that's possible to do from inside the `BufUnload` autocmd.