### PR TITLE
Add notice if closing commit without saving

### DIFF
--- a/lua/neogit/buffers/commit_editor/init.lua
+++ b/lua/neogit/buffers/commit_editor/init.lua
@@ -67,7 +67,9 @@ function M:open()
     mappings = {
       n = {
         ["q"] = function(buffer)
-          buffer:close(true)
+          if written or input.get_confirmation("Commit message isn't saved. Abort?") then
+            buffer:close(true)
+          end
         end,
       },
     },


### PR DESCRIPTION
Add notice if closing commit editor without writing message to disk, and use client.wrap for committing