### PR TITLE
fix: correctly detect the git root location

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -3,7 +3,6 @@ local logger = require("neogit.logger")
 local a = require("plenary.async")
 local process = require("neogit.process")
 local util = require("neogit.lib.util")
-local Path = require("plenary.path")
 
 local function config(setup)
   setup = setup or {}
@@ -449,9 +448,10 @@ local configurations = {
 
 -- TODO: Consider returning a Path object, since consumers of this function tend to need that anyways.
 local function git_root()
-  local dir = Path.new(".git")
-  if dir:exists() and dir:is_dir() then
-    return process.new({ cmd = { "git", "rev-parse", "--show-toplevel" } }):spawn_blocking().stdout[1]
+  local process = process.new({ cmd = { "git", "rev-parse", "--show-toplevel" } }):spawn_blocking()
+
+  if process ~= nil and process.code == 0 then
+    return process.stdout[1]
   else
     return ""
   end

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -448,7 +448,8 @@ local configurations = {
 
 -- TODO: Consider returning a Path object, since consumers of this function tend to need that anyways.
 local function git_root()
-  local process = process.new({ cmd = { "git", "rev-parse", "--show-toplevel" } }):spawn_blocking()
+  local process =
+    process.new({ cmd = { "git", "rev-parse", "--show-toplevel" }, ignore_code = true }):spawn_blocking()
 
   if process ~= nil and process.code == 0 then
     return process.stdout[1]


### PR DESCRIPTION
Currently the git root will not be correctly detected within symlinked directores not containing a `.git` directory within its upper paths. This PR resolves that issue by relying entirely upon `git rev-parse`. The commit 3149cd6fda556c9022b3e9dd03aee85a854be478 was created to remove "noisy output" when `git rev-parse` failed. This PR also resolves that issue by checking the return code emitted by `git rev-parse`.

See #575 for more details.

If this PR is not desired, feel free to close it out :smile:.

Closes #575