### PR TITLE
test: add tests for git root detection

### DIFF
--- a/tests/git_cli_spec.lua
+++ b/tests/git_cli_spec.lua
@@ -1,0 +1,43 @@
+local eq = assert.are.same
+local git_cli = require("neogit.lib.git.cli")
+local git_harness = require("tests.git_harness")
+local in_prepared_repo = git_harness.in_prepared_repo
+
+describe("git cli", function()
+  describe("root detection", function()
+    it(
+      "finds the correct git root for a non symlinked directory",
+      in_prepared_repo(function(root_dir)
+        local detected_root_dir = git_cli.git_root()
+        eq(detected_root_dir, root_dir)
+      end)
+    )
+
+    it(
+      "finds the correct git root for a symlinked directory without a .git dir in its upper paths",
+      in_prepared_repo(function(root_dir)
+        local git_dir = root_dir .. "/git-dir"
+        local git_sub_dir = root_dir .. "/sub-dir"
+        local symlink_dir = root_dir .. "/symlinked-dir"
+        local cmd = string.format(
+          [[
+          mkdir -p %s/%s
+          mv .git %s
+          ln -s %s/%s %s
+        ]],
+          git_dir,
+          git_sub_dir,
+          git_dir,
+          git_dir,
+          git_sub_dir,
+          symlink_dir
+        )
+        vim.fn.system(cmd)
+        vim.api.nvim_set_current_dir(symlink_dir)
+
+        local detected_root_dir = git_cli.git_root()
+        eq(detected_root_dir, git_dir)
+      end)
+    )
+  end)
+end)

--- a/tests/git_harness.lua
+++ b/tests/git_harness.lua
@@ -44,7 +44,7 @@ function M.in_prepared_repo(cb)
     require("neogit").setup()
     vim.cmd("Neogit")
     a.util.block_on(status.reset)
-    local _, err = pcall(cb)
+    local _, err = pcall(cb, dir)
     cleanup_repository(dir)
     if err ~= nil then
       error(err)


### PR DESCRIPTION
This commit also allows the `in_prepared_repo` harness to pass its directory to the function it wraps, which is necessary to check the root directory.

This helps with validation and checks of the git root directory, should help with avoiding the problem that cropped up in #575.