### PR TITLE
ci: cache selene install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,13 +14,10 @@ jobs:
           path: ~/.cargo/bin/selene
 
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Compare the cached Selene version against crates.io
         id: check-selene-cache
         run: |
-          CRATES_IO_SELENE_VERSION="$(cargo search selene --limit=1 --color=never | awk 'NR==1{gsub(/"/, "", $3); print $3}')"
+          CRATES_IO_SELENE_VERSION=$(curl -s -L0 https://crates.io/api/v1/crates/selene  | jq -r '.crate.max_stable_version')
           CACHED_SELENE_VERSION="$((selene --version || printf "INVALID_VERSION") | awk '{print $2}')"
 
           printf "Crates IO Selene Version: %s\n" "${CRATES_IO_SELENE_VERSION}"
@@ -34,6 +31,10 @@ jobs:
 
           printf "cache-valid=%s\n" "${CACHED_SELENE_VALID}" >> "${GITHUB_OUTPUT}"
 
+      - uses: actions-rs/toolchain@v1
+        if: ${{ steps.check-selene-cache.outputs.cache-valid != 'true'}}
+        with:
+          toolchain: stable
       - name: Install Selene
         if: ${{ steps.check-selene-cache.outputs.cache-valid != 'true'}}
         run: cargo install selene --force

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,46 @@ jobs:
   selene:
     runs-on: ubuntu-latest
     steps:
+      - name: Restore Cached Selene
+        id: cache-selene-restore
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-selene
+          path: ~/.cargo/bin/selene
+
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Compare the cached Selene version against crates.io
+        id: check-selene-cache
+        run: |
+          CRATES_IO_SELENE_VERSION="$(cargo search selene --limit=1 --color=never | awk 'NR==1{gsub(/"/, "", $3); print $3}')"
+          CACHED_SELENE_VERSION="$((selene --version || printf "INVALID_VERSION") | awk '{print $2}')"
+
+          printf "Crates IO Selene Version: %s\n" "${CRATES_IO_SELENE_VERSION}"
+          printf "Cached Selene Version:    %s\n" "${CACHED_SELENE_VERSION}"
+
+          CACHED_SELENE_VALID=false
+          if [[ "${CRATES_IO_SELENE_VERSION}" == "${CACHED_SELENE_VERSION}" ]]; then
+            CACHED_SELENE_VALID=true
+            printf "Cache is valid!\n"
+          fi
+
+          printf "cache-valid=%s\n" "${CACHED_SELENE_VALID}" >> "${GITHUB_OUTPUT}"
+
       - name: Install Selene
-        run: cargo install selene
+        if: ${{ steps.check-selene-cache.outputs.cache-valid != 'true'}}
+        run: cargo install selene --force
+
+      - name: Save New Selene Build to Cache
+        if: ${{ steps.check-selene-cache.outputs.cache-valid != 'true'}}
+        id: cache-selene-save
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ runner.os }}-selene
+          path: ~/.cargo/bin/selene
+
       - name: Run Selene
         run: make lint
   stylua:


### PR DESCRIPTION
This speeds up the Selene job in the lint action significantly when the cache is valid. Selene's last update was 4 months ago so there's really no need to be installing it on every run. Much faster to use a cache.

Take a look at [this run](https://github.com/treatybreaker/neogit/actions/runs/5556895200/jobs/10149993953) to see the speed up. It only took the Selene job ~9 seconds to complete with the cache.