### PR TITLE
Defer entering data into console until absolutely necessary

### DIFF
--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -108,40 +108,15 @@ local function create_preview_buffer()
   }
 end
 
---from https://github.com/stevearc/overseer.nvim/blob/82ed207195b58a73b9f7d013d6eb3c7d78674ac9/lua/overseer/util.lua#L119
----@param win number
-local function scroll_to_end(win)
-  local bufnr = vim.api.nvim_win_get_buf(win)
-  local lnum = vim.api.nvim_buf_line_count(bufnr)
-  local last_line = vim.api.nvim_buf_get_lines(bufnr, -2, -1, true)[1]
-  -- Hack: terminal buffers add a bunch of empty lines at the end. We need to ignore them so that
-  -- we don't end up scrolling off the end of the useful output.
-  -- This has the unfortunate effect that we may not end up tailing the output as more arrives
-  if vim.bo[bufnr].buftype == "terminal" then
-    local half_height = math.floor(vim.api.nvim_win_get_height(win) / 2)
-    for i = lnum, 1, -1 do
-      local prev_line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, true)[1]
-      if prev_line ~= "" then
-        -- Only scroll back if we detect a lot of padding lines, and the total real output is
-        -- small. Otherwise the padding may be legit
-        if lnum - i >= half_height and i < half_height then
-          lnum = i
-          last_line = prev_line
-        end
-        break
-      end
-    end
-  end
-  vim.api.nvim_win_set_cursor(win, { lnum, vim.api.nvim_strwidth(last_line) })
-end
-
 function Process.show_console()
   create_preview_buffer()
 
   vim.api.nvim_chan_send(vim.api.nvim_open_term(preview_buffer.buffer.handle, {}), preview_buffer.content)
-  local win = preview_buffer.buffer:show()
-  scroll_to_end(win)
-  vim.cmd.stopinsert() -- Ensures we're not in insert mode
+  preview_buffer.buffer:show()
+  -- Scroll to the end of viewable text
+  vim.cmd.startinsert()
+  vim.defer_fn(vim.cmd.stopinsert, 50)
+
   -- vim.api.nvim_win_call(win, function()
   --   vim.cmd.normal("G")
   -- end)


### PR DESCRIPTION
Prior to this commit the process module would spawn a Neovim terminal in the background immediately and write whatever data it needed to. This interferes with user auto commands for `TermOpen`. See #587 for an example.

This commit defers opening the terminal until absolutely necessary and writes all the data to it at that point. This ensures relevant auto commands for `TermOpen` are properly issued when the term is going to be actually used, not when its been backgrounded.

Another thing this commit does is improve the scroll function to use in-built functionality from Neovim instead of parsing the terminal buffer. By going into insert mode, waiting a small amount of time, and then exiting it ensures the cursor is directly at the end of viewable content.

Closes #587