### PR TITLE
fix: ensure floating popup windows are auto closed when they lose focus

### DIFF
--- a/lua/neogit/lib/popup.lua
+++ b/lua/neogit/lib/popup.lua
@@ -575,6 +575,19 @@ function M:show()
       }
     end,
   }
+
+  -- Closes the window if it loses focus and it is a floating buffer
+  if self.buffer.kind == "floating" then
+    vim.api.nvim_create_autocmd("WinLeave", {
+      callback = function(win)
+        if win.buf == self.buffer.handle then
+          -- We pcall this because it's possible the window was closed by a command invocation, e.g. "cc" for commits
+          pcall(self.close)
+        end
+      end,
+      once = true,
+    })
+  end
 end
 
 return M

--- a/lua/neogit/lib/popup.lua
+++ b/lua/neogit/lib/popup.lua
@@ -574,20 +574,15 @@ function M:show()
         },
       }
     end,
-  }
-
-  -- Closes the window if it loses focus and it is a floating buffer
-  if self.buffer.kind == "floating" then
-    vim.api.nvim_create_autocmd("WinLeave", {
-      callback = function(win)
-        if win.buf == self.buffer.handle then
+    autocmds = {
+      ["WinLeave"] = function()
+        if self.buffer.kind == "floating" then
           -- We pcall this because it's possible the window was closed by a command invocation, e.g. "cc" for commits
-          pcall(self.close)
+          pcall(self.close, self)
         end
       end,
-      once = true,
-    })
-  end
+    },
+  }
 end
 
 return M


### PR DESCRIPTION
Prior to this commit any floating windows that lost focus were not closed and covered the editor as well as being inaccessible in that state.

This commit ensures the window is properly cleaned up when it loses focus. This only applies to *floating* windows.

See #591 for more details.

Closes #591 