### PR TITLE
fix: do not directly modify the mapping config, use a copied value

### DIFF
--- a/lua/neogit/popups/help/actions.lua
+++ b/lua/neogit/popups/help/actions.lua
@@ -3,7 +3,10 @@ local M = {}
 local util = require("neogit.lib.util")
 local NONE = function() end
 
-local status_mappings = vim.tbl_add_reverse_lookup(require("neogit.config").values.mappings.status)
+-- Using deep extend this way creates a copy of the mapping values
+local status_mappings = vim.tbl_add_reverse_lookup(
+  vim.tbl_deep_extend("force", require("neogit.config").values.mappings.status, {})
+)
 
 local function present(commands)
   local presenter = util.map(commands, function(command)


### PR DESCRIPTION
Prior to this commit the reverse lookup done was directly modifying the `neogit.config.values.mappings.status` table which is not desired leaving status command names mapped (see `nmap Goto` for instance). We really want to modify a *copied* value to use later within the code to avoid mapping those commands. That is what this PR does.

See #561 for more details.

Closes #561