### PR TITLE
fix: use error code from `git rev-parse --is-inside-work-tree` to check if inside git directory

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -467,15 +467,13 @@ local git_dir_path_sync = function()
 end
 
 local git_is_repository_sync = function(cwd)
-  local result
-
   if not cwd then
-    result = vim.fn.system("git rev-parse --is-inside-work-tree")
+    vim.fn.system("git rev-parse --is-inside-work-tree")
   else
-    result = vim.fn.system(string.format("git -C %s rev-parse --is-inside-work-tree", cwd))
+    vim.fn.system(string.format("git -C %s rev-parse --is-inside-work-tree", cwd))
   end
 
-  return vim.trim(result) == "true"
+  return vim.v.shell_error == 0
 end
 
 local history = {}


### PR DESCRIPTION
In my case `/bin/bash` was spitting a warning message, which caused the string equality check to fail. It should be more robust to check for an exit code of 0 instead.