### PR TITLE
fix: ensure all created autocmds are part of the Neogit augroup

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -123,4 +123,5 @@ return {
   close = status.close,
   setup = setup,
   complete = complete,
+  autocmd_group = vim.api.nvim_create_augroup("Neogit", { clear = false }),
 }

--- a/lua/neogit/autocmds.lua
+++ b/lua/neogit/autocmds.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local api = vim.api
-local group = api.nvim_create_augroup("Neogit", { clear = true })
+M.group = api.nvim_create_augroup("Neogit", { clear = true })
 
 local a = require("plenary.async")
 local status = require("neogit.status")
@@ -28,7 +28,7 @@ function M.setup()
         status.refresh({ status = true, diffs = { "*:" .. path } }, string.format("%s:%s", o.event, o.file))
       end, function() end)
     end,
-    group = group,
+    group = M.group,
   })
 end
 

--- a/lua/neogit/autocmds.lua
+++ b/lua/neogit/autocmds.lua
@@ -1,11 +1,10 @@
 local M = {}
 
 local api = vim.api
-M.group = api.nvim_create_augroup("Neogit", { clear = true })
-
 local a = require("plenary.async")
 local status = require("neogit.status")
 local fs = require("neogit.lib.fs")
+local group = require("neogit").autocmd_group
 
 function M.setup()
   api.nvim_create_autocmd({ "BufWritePost", "ShellCmdPost", "VimResume" }, {
@@ -28,7 +27,7 @@ function M.setup()
         status.refresh({ status = true, diffs = { "*:" .. path } }, string.format("%s:%s", o.event, o.file))
       end, function() end)
     end,
-    group = M.group,
+    group = group,
   })
 end
 

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -401,7 +401,7 @@ function Buffer.create(config)
     buffer.ui:render(unpack(config.render(buffer)))
   end
 
-  local neogit_augroup = require("neogit.autocmds").group
+  local neogit_augroup = require("neogit").autocmd_group
   for event, callback in pairs(config.autocmds or {}) do
     api.nvim_create_autocmd(event, { callback = callback, buffer = buffer.handle, group = neogit_augroup })
   end

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -401,8 +401,9 @@ function Buffer.create(config)
     buffer.ui:render(unpack(config.render(buffer)))
   end
 
+  local neogit_augroup = require("neogit.autocmds").group
   for event, callback in pairs(config.autocmds or {}) do
-    api.nvim_create_autocmd(event, { callback = callback, buffer = buffer.handle })
+    api.nvim_create_autocmd(event, { callback = callback, buffer = buffer.handle, group = neogit_augroup })
   end
 
   buffer.mmanager.register()


### PR DESCRIPTION
Prior to this PR using `vim.api.nvim_get_autocmds({ group = "Neogit" })` would only return the initial `setup` autocmds that Neogit created. It did *not* return the autocmds created for the buffers that Neogit created.

This PR enables users to get all the autocmds that Neogit creates. It does this by exporting the augroup in `autocmds.lua` and then importing it in `buffer.lua` so they share the same augroup.

Something to note, we may want to create a different `augroup` for the Neogit buffers in `buffer.lua` instead of using the same `augroup` in `autocmds.lua`, though it may make it a bit more difficult to search for.