### PR TITLE
feat: do not close commit message with `q` until saved

### DIFF
--- a/lua/neogit/buffers/commit_editor/init.lua
+++ b/lua/neogit/buffers/commit_editor/init.lua
@@ -67,7 +67,15 @@ function M:open()
     mappings = {
       n = {
         ["q"] = function(buffer)
-          buffer:close(true)
+          if buffer:get_option("modified") then
+            require("neogit.lib.notification").create(
+              "Commit message has not been saved! Try `:w`.",
+              vim.log.levels.WARN
+            )
+          else
+            self:close()
+            buffer:close(true)
+          end
         end,
       },
     },

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -226,7 +226,7 @@ function Buffer:unlock()
 end
 
 function Buffer:get_option(name)
-  api.nvim_buf_get_option(self.handle, name)
+  return api.nvim_buf_get_option(self.handle, name)
 end
 
 function Buffer:set_option(name, value)


### PR DESCRIPTION
Prior to this commit hitting `q` in normal mode in the commit editor would close it even if the text had not been saved. Also, prior to this commit, the `Buffer:get_option` in `lib/buffer.lua` never actually returned the option value :sweat_smile:. 

This PR pops up a warning when `q` is hit in normal mode and the buffer has unsaved modifications, we may want to change the message and the log level. 
Currently the message is: 
> Commit message has not been saved! Try `:w`.

 and the log level is set to `WARN`.

This PR also fixes the `Buffer:get_option` to *actually* return the value it got.


Let me know if any changes are desired to the message or log level, and secondly I have a question. Do y'all prefer me to force push or to create a separate commit for each change? Usually I try to avoid polluting the git history with a bunch of teeny tiny fix commits, but y'all may prefer that.


Closes #552