### PR TITLE
fix: show the correctly bound key for the top Status Hint

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+function M.get_reversed_status_maps()
+  return vim.tbl_add_reverse_lookup(vim.tbl_deep_extend("force", M.values.mappings.status, {}))
+end
+
 M.values = {
   disable_hint = false,
   disable_context_highlighting = false,

--- a/lua/neogit/popups/help/actions.lua
+++ b/lua/neogit/popups/help/actions.lua
@@ -4,9 +4,7 @@ local util = require("neogit.lib.util")
 local NONE = function() end
 
 -- Using deep extend this way creates a copy of the mapping values
-local status_mappings = vim.tbl_add_reverse_lookup(
-  vim.tbl_deep_extend("force", require("neogit.config").values.mappings.status, {})
-)
+local status_mappings = require("neogit.config").get_reversed_status_maps()
 
 local function present(commands)
   local presenter = util.map(commands, function(command)

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -152,7 +152,22 @@ local function draw_buffer()
 
   local output = LineBuffer.new()
   if not config.values.disable_hint then
-    output:append("Hint: [<tab>] toggle diff | [s]tage | [u]nstage | [x] discard | [c]ommit | [?] more help")
+    local reversed_status_map = config.get_reversed_status_maps()
+
+    local function hint_label(map_name, hint)
+      return "[" .. reversed_status_map[map_name] .. "] " .. hint
+    end
+
+    local hints = {
+      hint_label("Toggle", "toggle diff"),
+      hint_label("Stage", "stage"),
+      hint_label("Unstage", "unstage"),
+      hint_label("Discard", "discard"),
+      hint_label("CommitPopup", "commit"),
+      hint_label("HelpPopup", "help"),
+    }
+
+    output:append("Hint: " .. table.concat(hints, " | "))
     output:append("")
   end
 


### PR DESCRIPTION
Prior to this PR the top hint the status buffer was hardcoded to show certain keys.

This PR checks the keymap and inserts the correct key for the top hints, unfortunately this does impact the way the keys look in the hint:
![image](https://github.com/NeogitOrg/neogit/assets/58627896/a7346f3d-a7c6-43ba-a7f3-d7aa9da131a4)

This PR also adds a function `get_reversed_status_map` to `config.lua` and uses that for the reversed mapping lookup.

Fixes #564 (partially)