### PR TITLE
fix: do not setup colors in headless mode

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -20,7 +20,11 @@ local notification = require("neogit.lib.notification")
 
 local did_setup = false
 
-local setup = function(opts)
+local setup = function(opts, setup_highlights)
+  if setup_highlights == nil then
+    setup_highlights = (#vim.api.nvim_list_uis() ~= 0)
+  end
+
   if did_setup then
     logger.debug("Already did setup!")
     return
@@ -36,7 +40,11 @@ local setup = function(opts)
     config.values.mappings.status["p"] = ""
   end
 
-  hl.setup()
+  -- If we're in headless mode we want to skip setting up highlights,
+  if setup_highlights then
+    hl.setup()
+  end
+
   signs.setup()
   state.setup()
 


### PR DESCRIPTION
Prior to this PR headless & embed Neovim environments would throw an error in some scenarios. This PR adds a guard statement (with a forceable override) to not setup the highlights if we detect we're within a headless or embedded Neovim instance.

Closes #622 

