### PR TITLE
fix: properly access the current git branch via an accessor

### DIFF
--- a/lua/neogit/popups/branch/init.lua
+++ b/lua/neogit/popups/branch/init.lua
@@ -6,7 +6,7 @@ local actions = require("neogit.popups.branch.actions")
 local config_actions = require("neogit.popups.branch_config.actions")
 
 function M.create()
-  local current_branch = git.repo.head.branch or ""
+  local current_branch = git.branch.current()
   local show_config = current_branch ~= "" and current_branch ~= "(detached)"
   local pull_rebase_entry = git.config.get("pull.rebase")
   local pull_rebase = pull_rebase_entry:is_set() and pull_rebase_entry.value or "false"

--- a/lua/neogit/popups/branch_config/init.lua
+++ b/lua/neogit/popups/branch_config/init.lua
@@ -5,7 +5,7 @@ local git = require("neogit.lib.git")
 local actions = require("neogit.popups.branch_config.actions")
 
 function M.create(branch)
-  branch = branch or git.repo.head.branch
+  branch = branch or git.branch.current()
   local g_pull_rebase = git.config.get_global("pull.rebase")
   local pull_rebase_entry = git.config.get("pull.rebase")
   local pull_rebase = pull_rebase_entry:is_set() and pull_rebase_entry.value or "false"

--- a/lua/neogit/popups/pull/init.lua
+++ b/lua/neogit/popups/pull/init.lua
@@ -5,7 +5,7 @@ local popup = require("neogit.lib.popup")
 local M = {}
 
 function M.create()
-  local current = git.repo.head.branch
+  local current = git.branch.current()
   local show_config = current ~= "" and current ~= "(detached)"
   local pull_rebase_entry = git.config.get("pull.rebase")
   local pull_rebase = pull_rebase_entry:is_set() and pull_rebase_entry.value or "false"

--- a/lua/neogit/popups/push/init.lua
+++ b/lua/neogit/popups/push/init.lua
@@ -5,7 +5,7 @@ local git = require("neogit.lib.git")
 local M = {}
 
 function M.create()
-  local current = git.repo.head.branch
+  local current = git.branch.current()
 
   local p = popup
     .builder()

--- a/lua/neogit/popups/rebase/init.lua
+++ b/lua/neogit/popups/rebase/init.lua
@@ -5,7 +5,7 @@ local actions = require("neogit.popups.rebase.actions")
 local M = {}
 
 function M.create(commit)
-  local branch = git.repo.head.branch
+  local branch = git.branch.current()
   local in_rebase = git.repo.rebase.head
   local base_branch = actions.base_branch()
 


### PR DESCRIPTION
This makes popups that were being called by `require("neogit.popups").call("POPUP_HERE")()` work correctly prior to the Neogit status being opened.

This PR will cause an early return when neither a head branch or a current branch is detected to avoid any errors.

Fixes #639 