### PR TITLE
Perf: Speed-up buffer updates

### DIFF
--- a/lua/neogit/buffers/commit_editor/init.lua
+++ b/lua/neogit/buffers/commit_editor/init.lua
@@ -50,7 +50,7 @@ function M:open()
             and not input.get_confirmation("Are you sure you want to commit?")
           then
             -- Clear the buffer, without filling the register
-            buf:set_lines(0, -1, false, {})
+            buf:clear()
             buf:call(function()
               vim.cmd("silent w!")
             end)

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -25,6 +25,10 @@ function Buffer:new(handle)
     border = nil,
     mmanager = mappings_manager.new(handle),
     kind = nil, -- how the buffer was opened. For more information look at the create function
+    line_buffer = {},
+    hl_buffer = {},
+    sign_buffer = {},
+    ext_buffer = {},
   }
 
   this.ui = Ui.new(this)
@@ -81,6 +85,46 @@ end
 
 function Buffer:set_lines(first, last, strict, lines)
   api.nvim_buf_set_lines(self.handle, first, last, strict, lines)
+end
+
+function Buffer:set_line_buffer(line)
+  table.insert(self.line_buffer, line)
+end
+
+function Buffer:add_highlight_buffer(...)
+  table.insert(self.hl_buffer, { ... })
+end
+
+function Buffer:place_sign_buffer(...)
+  table.insert(self.sign_buffer, { ... })
+end
+
+function Buffer:set_extmark_buffer(...)
+  table.insert(self.ext_buffer, { ... })
+end
+
+function Buffer:resize(length)
+  api.nvim_buf_set_lines(self.handle, length, -1, false, {})
+end
+
+function Buffer:flush_buffers()
+  api.nvim_buf_set_lines(self.handle, 0, -1, false, self.line_buffer)
+  self.line_buffer = {}
+
+  for _, sign in ipairs(self.sign_buffer) do
+    self:place_sign(unpack(sign))
+  end
+  self.sign_buffer = {}
+
+  for _, hl in ipairs(self.hl_buffer) do
+    self:add_highlight(unpack(hl))
+  end
+  self.hl_buffer = {}
+
+  for _, ext in ipairs(self.ext_buffer) do
+    self:set_extmark(unpack(ext))
+  end
+  self.ext_buffer = {}
 end
 
 function Buffer:set_text(first_line, last_line, first_col, last_col, lines)

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -25,6 +25,7 @@ function Buffer:new(handle)
     border = nil,
     mmanager = mappings_manager.new(handle),
     kind = nil, -- how the buffer was opened. For more information look at the create function
+    namespace = api.nvim_create_namespace("neogit-buffer-" .. handle),
     line_buffer = {},
     hl_buffer = {},
     sign_buffer = {},
@@ -108,6 +109,8 @@ function Buffer:resize(length)
 end
 
 function Buffer:flush_buffers()
+  self:clear_namespace(self.namespace)
+
   api.nvim_buf_set_lines(self.handle, 0, -1, false, self.line_buffer)
   self.line_buffer = {}
 
@@ -304,7 +307,7 @@ function Buffer:open_fold(line, reset_pos)
 end
 
 function Buffer:add_highlight(line, col_start, col_end, name, ns_id)
-  local ns_id = ns_id or 0
+  local ns_id = ns_id or self.namespace
 
   api.nvim_buf_add_highlight(self.handle, ns_id, name, line, col_start, col_end)
 end

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -88,19 +88,19 @@ function Buffer:set_lines(first, last, strict, lines)
   api.nvim_buf_set_lines(self.handle, first, last, strict, lines)
 end
 
-function Buffer:set_line_buffer(line)
+function Buffer:buffered_set_line(line)
   table.insert(self.line_buffer, line)
 end
 
-function Buffer:add_highlight_buffer(...)
+function Buffer:buffered_add_highlight(...)
   table.insert(self.hl_buffer, { ... })
 end
 
-function Buffer:place_sign_buffer(...)
+function Buffer:buffered_place_sign(...)
   table.insert(self.sign_buffer, { ... })
 end
 
-function Buffer:set_extmark_buffer(...)
+function Buffer:buffered_set_extmark(...)
   table.insert(self.ext_buffer, { ... })
 end
 

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -289,7 +289,7 @@ function Buffer:set_foldlevel(level)
 end
 
 function Buffer:replace_content_with(lines)
-  self:set_lines(0, -1, false, lines)
+  api.nvim_buf_set_lines(self.handle, 0, -1, false, lines)
 end
 
 function Buffer:open_fold(line, reset_pos)

--- a/lua/neogit/lib/ui/init.lua
+++ b/lua/neogit/lib/ui/init.lua
@@ -237,10 +237,10 @@ function Ui:_render(first_line, first_col, parent, components, flags)
     end
 
     if not flags.hidden then
-      self.buf:set_line_buffer(table.concat(text))
+      self.buf:buffered_set_line(table.concat(text))
 
       for _, h in ipairs(highlights) do
-        self.buf:add_highlight_buffer(curr_line - 1, h.from, h.to, h.name)
+        self.buf:buffered_add_highlight(curr_line - 1, h.from, h.to, h.name)
       end
 
       curr_line = curr_line + 1
@@ -260,10 +260,10 @@ function Ui:_render(first_line, first_col, parent, components, flags)
 
         if c.tag == "text" then
           if not flags.hidden then
-            self.buf:set_line_buffer(table.concat { c:get_padding_left(), c.value })
+            self.buf:buffered_set_line(table.concat { c:get_padding_left(), c.value })
 
             if highlight then
-              self.buf:add_highlight_buffer(
+              self.buf:buffered_add_highlight(
                 curr_line - 1,
                 c.position.col_start,
                 c.position.col_end,
@@ -272,7 +272,7 @@ function Ui:_render(first_line, first_col, parent, components, flags)
             end
 
             if sign then
-              self.buf:place_sign_buffer(curr_line, sign, "hl")
+              self.buf:buffered_place_sign(curr_line, sign, "hl")
             end
 
             curr_line = curr_line + 1
@@ -284,12 +284,12 @@ function Ui:_render(first_line, first_col, parent, components, flags)
           curr_line = curr_line + self:_render(curr_line, 0, c, c.children, flags)
 
           if not flags.hidden and sign then
-            self.buf:place_sign_buffer(curr_line - 1, sign, "hl")
+            self.buf:buffered_place_sign(curr_line - 1, sign, "hl")
           end
 
           if not flags.hidden and c.options.virtual_text then
             local ns = self.buf:create_namespace("NeogitBufferVirtualText")
-            self.buf:set_extmark_buffer(ns, curr_line - 2, 0, {
+            self.buf:buffered_set_extmark(ns, curr_line - 2, 0, {
               hl_mode = "combine",
               virt_text = c.options.virtual_text,
               virt_text_pos = "right_align",

--- a/lua/neogit/lib/ui/init.lua
+++ b/lua/neogit/lib/ui/init.lua
@@ -240,7 +240,7 @@ function Ui:_render(first_line, first_col, parent, components, flags)
       self.buf:set_line_buffer(table.concat(text))
 
       for _, h in ipairs(highlights) do
-        self.buf:add_highlight_buffer(curr_line - 1, h.from, h.to, h.name, 0)
+        self.buf:add_highlight_buffer(curr_line - 1, h.from, h.to, h.name)
       end
 
       curr_line = curr_line + 1
@@ -263,7 +263,7 @@ function Ui:_render(first_line, first_col, parent, components, flags)
             self.buf:set_line_buffer(table.concat { c:get_padding_left(), c.value })
 
             if highlight then
-              self.buf:add_highlight_buffer(curr_line - 1, c.position.col_start, c.position.col_end, highlight, 0)
+              self.buf:add_highlight_buffer(curr_line - 1, c.position.col_start, c.position.col_end, highlight)
             end
 
             if sign then

--- a/lua/neogit/lib/ui/init.lua
+++ b/lua/neogit/lib/ui/init.lua
@@ -153,8 +153,6 @@ function Ui.visualize_tree(components, options)
   Ui._visualize_tree(1, components, options or {})
 end
 
--- TODO: Rewrite this to use a table as a linewise buffer instead of a string, since appending strings in LUA is
--- expensive compared to inserting into a table. Call table.concat(line) right before appending to buffer.
 function Ui:_render(first_line, first_col, parent, components, flags)
   local curr_line = first_line
 
@@ -162,18 +160,21 @@ function Ui:_render(first_line, first_col, parent, components, flags)
     local col_start = first_col
     local col_end
     local highlights = {}
-    local text = ""
+    local text = {}
 
     for i, c in ipairs(components) do
       c.parent = parent
       c.index = i
+
       if not c.options.hidden then
         c.position = {}
         c.position.row_start = curr_line - first_line + 1
+
         local highlight = c:get_highlight()
+
         if c.tag == "text" then
           local padding_left = flags.in_nested_row and "" or c:get_padding_left(i == 1)
-          text = padding_left .. text
+          table.insert(text, 1, padding_left)
 
           col_start = col_start + #padding_left
           col_end = col_start + c:get_width()
@@ -181,9 +182,10 @@ function Ui:_render(first_line, first_col, parent, components, flags)
           c.position.col_end = col_end - 1
 
           if c.options.align_right then
-            text = text .. c.value .. (" "):rep(c.options.align_right - #c.value)
+            table.insert(text, c.value)
+            table.insert(text, (" "):rep(c.options.align_right - #c.value))
           else
-            text = text .. c.value
+            table.insert(text, c.value)
           end
 
           if highlight then
@@ -193,20 +195,22 @@ function Ui:_render(first_line, first_col, parent, components, flags)
               name = highlight,
             })
           end
+
           col_start = col_end
         elseif c.tag == "row" then
           flags.in_nested_row = true
+
           local padding_left = flags.in_nested_row and "" or c:get_padding_left(i == 1)
           local res = self:_render(curr_line, col_start, c, c.children, flags)
-          flags.in_nested_row = false
 
-          res.text = padding_left .. res.text
+          flags.in_nested_row = false
 
           if c.position.col_end then
             c.position.col_end = c.position.col_end + #padding_left
           end
 
-          text = text .. res.text
+          table.insert(text, padding_left)
+          table.insert(text, res.text)
 
           for _, h in ipairs(res.highlights) do
             h.to = h.to + #padding_left
@@ -220,28 +224,32 @@ function Ui:_render(first_line, first_col, parent, components, flags)
         else
           error("The row component does not support having a `" .. c.tag .. "` as child")
         end
+
         c.position.row_end = c.position.row_start
       end
     end
 
     if flags.in_nested_row then
       return {
-        text = text,
+        text = table.concat(text),
         highlights = highlights,
       }
     end
 
-    self.buf:set_lines(curr_line - 1, curr_line, false, { text })
+    if not flags.hidden then
+      self.buf:set_line_buffer(table.concat(text))
 
-    for _, h in ipairs(highlights) do
-      self.buf:add_highlight(curr_line - 1, h.from, h.to, h.name, 0)
+      for _, h in ipairs(highlights) do
+        self.buf:add_highlight_buffer(curr_line - 1, h.from, h.to, h.name, 0)
+      end
+
+      curr_line = curr_line + 1
     end
-
-    curr_line = curr_line + 1
   else
     for i, c in ipairs(components) do
       c.parent = parent
       c.index = i
+
       if not c.options.hidden then
         c.position = {}
         c.position.row_start = curr_line - first_line + 1
@@ -249,37 +257,47 @@ function Ui:_render(first_line, first_col, parent, components, flags)
         c.position.col_end = -1
         local sign = c:get_sign()
         local highlight = c:get_highlight()
+
         if c.tag == "text" then
-          local padding_left = c:get_padding_left()
-          local text = padding_left .. c.value
-          self.buf:set_lines(curr_line - 1, curr_line, false, { text })
-          if highlight then
-            self.buf:add_highlight(curr_line - 1, c.position.col_start, c.position.col_end, highlight, 0)
+          if not flags.hidden then
+            self.buf:set_line_buffer(table.concat { c:get_padding_left(), c.value })
+
+            if highlight then
+              self.buf:add_highlight_buffer(curr_line - 1, c.position.col_start, c.position.col_end, highlight, 0)
+            end
+
+            if sign then
+              self.buf:place_sign_buffer(curr_line, sign, "hl")
+            end
+
+            curr_line = curr_line + 1
           end
-          if sign then
-            self.buf:place_sign(curr_line, sign, "hl")
-          end
-          curr_line = curr_line + 1
         elseif c.tag == "col" then
           curr_line = curr_line + self:_render(curr_line, 0, c, c.children, flags)
         elseif c.tag == "row" then
           flags.in_row = true
           curr_line = curr_line + self:_render(curr_line, 0, c, c.children, flags)
-          if sign then
-            self.buf:place_sign(curr_line - 1, sign, "hl")
+
+          if not flags.hidden and sign then
+            self.buf:place_sign_buffer(curr_line - 1, sign, "hl")
           end
-          if c.options.virtual_text then
+
+          if not flags.hidden and c.options.virtual_text then
             local ns = self.buf:create_namespace("NeogitBufferVirtualText")
-            self.buf:set_extmark(ns, curr_line - 2, 0, {
+            self.buf:set_extmark_buffer(ns, curr_line - 2, 0, {
               hl_mode = "combine",
               virt_text = c.options.virtual_text,
               virt_text_pos = "right_align",
             })
           end
+
           flags.in_row = false
         end
+
         c.position.row_end = curr_line - first_line
       else
+        flags.hidden = true
+
         if c.tag == "col" then
           self:_render(curr_line, 0, c, c.children, flags)
         elseif c.tag == "row" then
@@ -287,6 +305,8 @@ function Ui:_render(first_line, first_col, parent, components, flags)
           self:_render(curr_line, 0, c, c.children, flags)
           flags.in_row = false
         end
+
+        flags.hidden = false
       end
     end
   end
@@ -317,7 +337,8 @@ function Ui:update()
     self.layout,
     {}
   )
-  self.buf:set_lines(lines_used, -1, false, {})
+  self.buf:resize(lines_used)
+  self.buf:flush_buffers()
   self.buf:lock()
 end
 

--- a/lua/neogit/lib/ui/init.lua
+++ b/lua/neogit/lib/ui/init.lua
@@ -263,7 +263,12 @@ function Ui:_render(first_line, first_col, parent, components, flags)
             self.buf:set_line_buffer(table.concat { c:get_padding_left(), c.value })
 
             if highlight then
-              self.buf:add_highlight_buffer(curr_line - 1, c.position.col_start, c.position.col_end, highlight)
+              self.buf:add_highlight_buffer(
+                curr_line - 1,
+                c.position.col_start,
+                c.position.col_end,
+                highlight
+              )
             end
 
             if sign then


### PR DESCRIPTION
Speed-up redrawing by using buffers for lines/highlights/signs/extmarks and only flush buffers once. Test this by opening the `LogView` and toggling open and closed a commit (via `<tab>`). On master... slow. On this branch, faster.

before:
<img width="1661" alt="Screenshot 2023-07-19 at 09 44 35" src="https://github.com/NeogitOrg/neogit/assets/7228095/8fbfdcbf-ebea-4580-b89d-38efc21ef547">

after:
<img width="1656" alt="Screenshot 2023-07-19 at 10 03 50" src="https://github.com/NeogitOrg/neogit/assets/7228095/23ad1b0e-f4b6-475a-acba-1cfe6f5a8e3d">

I'm not sure if I can get the `add_highlight` call to be any faster, but thats the next thing to try.
