### PR TITLE
Breaking: Update default ignored flags

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -41,8 +41,14 @@ Neogit is a magit clone for Neovim that is currently work in progress.
 ==============================================================================
 2. Commands                                     *neogit-commands*
 
-                                                *:Neogit*           
+                                                *:Neogit*
 :Neogit                 In a Git repository, opens a new NeogitStatus tab.
+
+                                                *:NeogitMessages*
+:NeogitMessages         Prints messages from neogit's messaging system.
+
+                                                *:NeogitResetState*
+:NeogitResetState       Performs a full reset of saved flags for all popups.
 
 ==============================================================================
 3. Mappings                                      *neogit-mappings*

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -94,6 +94,7 @@ M.values = {
   ignored_settings = {
     "NeogitPushPopup--force-with-lease",
     "NeogitPushPopup--force",
+    "NeogitPullPopup--rebase",
     "NeogitCommitPopup--allow-empty",
     "NeogitRevertPopup--no-edit", -- TODO: Fix incompatible switches with default enables
   },

--- a/plugin/neogit.lua
+++ b/plugin/neogit.lua
@@ -20,3 +20,11 @@ end, {
   nargs = "*",
   desc = "Prints neogit message history",
 })
+
+api.nvim_create_user_command(
+  "NeogitResetState",
+  function()
+    require("neogit.lib.state")._reset()
+  end,
+  { nargs = "*", desc = "Reset any saved flags" }
+)


### PR DESCRIPTION
Add pull popup flag '--rebase' to ignored settings. This value is handled by a config value, so shouldn't be persisted.

If you experience issues, use `:NeogitResetState` to fix it.