### PR TITLE
Fix #669

### DIFF
--- a/lua/neogit/popups/commit/actions.lua
+++ b/lua/neogit/popups/commit/actions.lua
@@ -8,11 +8,12 @@ local a = require("plenary.async")
 
 local function confirm_modifications()
   if
-    #git.repo.unmerged.items < 1
+    git.branch.upstream()
+    and #git.repo.unmerged.items < 1
     and not input.get_confirmation(
       string.format(
         "This commit has already been published to %s, do you really want to modify it?",
-        git.repo.upstream.ref
+        git.branch.upstream()
       ),
       { values = { "&Yes", "&No" }, default = 2 }
     )


### PR DESCRIPTION
Only ask for confirmation if an upstream is set for the branch

Fixes #669 