### PR TITLE
Bugfix: after closing the telescope prompt, the focus wouldn't go back

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -5,6 +5,15 @@ local function telescope_mappings(on_select, allow_multi)
   local action_state = require("telescope.actions.state")
   local actions = require("telescope.actions")
 
+  local function close_action(prompt_bufnr)
+    actions.close(prompt_bufnr)
+
+    local status = require("neogit.status")
+    if status.status_buffer then
+      status.status_buffer:focus()
+    end
+  end
+
   --- Lift the picker select action to a item select action
   local function select_action(prompt_bufnr)
     local selection = {}
@@ -22,7 +31,7 @@ local function telescope_mappings(on_select, allow_multi)
       return
     end
 
-    actions.close(prompt_bufnr)
+    close_action(prompt_bufnr)
 
     if allow_multi then
       on_select(selection)
@@ -37,7 +46,7 @@ local function telescope_mappings(on_select, allow_multi)
       ["Close"] = function(...)
         -- Make sure to notify the caller that we aborted to avoid hanging on the async task forever
         on_select(nil)
-        actions.close(...)
+        close_action(...)
       end,
       ["Next"] = actions.move_selection_next,
       ["Previous"] = actions.move_selection_previous,


### PR DESCRIPTION
after closing the telescope prompt, the focus wouldn't go back to the neogit buffer if it was open as a split.

This ensures that the status buffer is refocused just before the on_select function is called. If on_select() opens a new popup, then the popup is correctly split from the status buffer.

Fixes #689 