### PR TITLE
Add cherry-pick popup documentation

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -438,10 +438,10 @@ Actions:                                      *neogit_cherry_pick_popup_actions*
 Branch Popup                                               *neogit_branch_popup*
 
 Variables:                                       *neogit_branch_popup_variables*
-  -  branch.<name>.description
+  - branch.<name>.description
 
-  -  branch.<name>.merge
-     branch.<name>.remote
+  - branch.<name>.merge
+    branch.<name>.remote
 
   - branch.<name>.rebase
     Cycles branch.<name>.rebase value between true, false, and the value of
@@ -453,8 +453,18 @@ Variables:                                       *neogit_branch_popup_variables*
     repository. `remote.pushDefault` will be offered, if set.
 
 Arguments:                                            *neogit_branch_popup_args*
-  - recurse-submodules
-    Recurse submodules when checking out an existing branch
+  - --recurse-submodules
+    (EXPERIMENTAL) Causes the current command to recurse into submodules if
+    submodule.propagateBranches is enabled.
+
+    When used in branch creation, a new branch <branchname> will be created
+    in the superproject and all of the submodules in the superproject’s
+    <start-point>. In submodules, the branch will point to the submodule
+    commit in the superproject’s <start-point> but the branch’s tracking
+    information will be set up based on the submodule’s branches and remotes
+    e.g.  git branch --recurse-submodules topic origin/main will create the
+    submodule branch "topic" that points to the submodule commit in the
+    superproject’s "origin/main", but tracks the submodule’s "origin/main".
 
 Actions:                                           *neogit_branch_popup_actions*
   Actions for the branch popup are split into three categories: "Checkout",

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -381,6 +381,60 @@ git mechanism.
 "stash"              see :Man git-stash
 
 ==============================================================================
+Cherry-Pick Popup                                     *neogit_cherry_pick_popup*
+
+Arguments:                                       *neogit_cherry_pick_popup_args*
+  - --ff
+    If the current HEAD is the same as the parent of the cherry-pick’ed
+    commit, then a fast forward to this commit will be performed.
+
+Actions:                                      *neogit_cherry_pick_popup_actions*
+  Actions for the branch popup are split into two categories: "Apply here",
+  and "Apply elsewhere". The former will update the current HEAD, whereas the
+  latter will prompt for a target.
+
+  When a Cherry-Pick isn't in progress, the following actions are available:
+
+  - Pick                                               *neogit_cherry_pick_pick*
+    This command copies COMMITS from another branch onto the current branch.
+    If a commit is under the cursor, or multiple commits are selected, then
+    those are used instead of prompting. Otherwise the user is prompted to
+    select one or more commits.
+
+  - Apply                                             *neogit_cherry_pick_apply*
+    This command applies the changes in COMMITS from another branch onto the
+    current branch, without committing. If a commit is under the cursor, or
+    multiple commits are selected, then those are used instead of prompting.
+    Otherwise the user is prompted to select one or more commits.
+
+  - Harvest                                         *neogit_cherry_pick_harvest*
+    (not yet implemented)
+
+  - Squash                                           *neogit_cherry_pick_squash*
+    (not yet implemented)
+
+  - Donate                                           *neogit_cherry_pick_donate*
+    (not yet implemented)
+
+  - Spinout                                         *neogit_cherry_pick_spinout*
+    (not yet implemented)
+
+  - Spinoff                                         *neogit_cherry_pick_spinoff*
+    (not yet implemented)
+
+
+  When a Cherry-Pick is in progress, the following actions are available:
+
+  - Continue                                       *neogit_cherry_pick_continue*
+    Resume current cherry-pick sequence.
+
+  - Skip                                               *neogit_cherry_pick_skip*
+    Skip the current commit during a cherry-pick sequence.
+
+  - Abort                                             *neogit_cherry_pick_abort*
+    Abort the current cherry-pick sequence. This discards all changes made.
+
+==============================================================================
 Branch Popup                                               *neogit_branch_popup*
 
 Variables:                                       *neogit_branch_popup_variables*

--- a/lua/neogit/buffers/commit_select_view/init.lua
+++ b/lua/neogit/buffers/commit_select_view/init.lua
@@ -2,6 +2,7 @@ local a = require("plenary.async")
 local Buffer = require("neogit.lib.buffer")
 local ui = require("neogit.buffers.commit_select_view.ui")
 local config = require("neogit.config")
+local util = require("neogit.lib.util")
 
 ---@class CommitSelectViewBuffer
 ---@field commits CommitLogEntry[]
@@ -43,6 +44,28 @@ function M:open(action)
     filetype = "NeogitCommitSelectView",
     kind = config.values.commit_select_view.kind,
     mappings = {
+      v = {
+        ["<enter>"] = function()
+          local commits = util.filter_map(
+            self.buffer.ui:get_component_stack_in_linewise_selection(),
+            function(c)
+              if c.options.oid then
+                return c.options.oid
+              end
+            end
+          )
+
+
+          if action and commits[1] then
+            vim.schedule(function()
+              self:close()
+            end)
+
+            action(util.reverse(commits))
+            action = nil
+          end
+        end,
+      },
       n = {
         ["<tab>"] = function()
           -- no-op

--- a/lua/neogit/buffers/commit_select_view/init.lua
+++ b/lua/neogit/buffers/commit_select_view/init.lua
@@ -55,7 +55,6 @@ function M:open(action)
             end
           )
 
-
           if action and commits[1] then
             vim.schedule(function()
               self:close()

--- a/lua/neogit/buffers/log_view/init.lua
+++ b/lua/neogit/buffers/log_view/init.lua
@@ -52,7 +52,7 @@ function M:open()
             end
           )
 
-          CherryPickPopup.create { commits = commits }
+          CherryPickPopup.create { commits = util.reverse(commits) }
         end,
         ["v"] = function()
           -- local commits = util.filter_map(

--- a/lua/neogit/buffers/reflog_view/init.lua
+++ b/lua/neogit/buffers/reflog_view/init.lua
@@ -48,7 +48,7 @@ function M:open()
             end
           )
 
-          CherryPickPopup.create { commits = commits }
+          CherryPickPopup.create { commits = util.reverse(commits) }
         end,
         ["v"] = function()
           -- local commits = util.filter_map(

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -30,6 +30,21 @@ local function flatten(tbl)
 end
 
 ---@generic T: any
+---@param tbl T[]
+---@return T[]
+--- Reverses list-like table
+local function reverse(tbl)
+  local t = {}
+  local c = #tbl + 1
+
+  for i, v in ipairs(tbl) do
+    t[c - i] = v
+  end
+
+  return t
+end
+
+---@generic T: any
 ---@generic U: any
 ---@param list T[]
 ---@param f fun(v: T): U|nil
@@ -331,4 +346,5 @@ return {
   remove_item_from_table = remove_item_from_table,
   lists_equal = lists_equal,
   pad_right = pad_right,
+  reverse = reverse,
 }


### PR DESCRIPTION
Also add `util.reverse` to reverse a list-like table, and ensure commits are passed to cherry-pick popup in reverse order (oldest first)