### PR TITLE
Follow highlight links

### DIFF
--- a/lua/neogit/lib/hl.lua
+++ b/lua/neogit/lib/hl.lua
@@ -29,17 +29,23 @@ end
 
 ---@param name string Syntax group name.
 local function get_fg(name)
-  local color = vim.api.nvim_get_hl(0, { name = name })["fg"]
-  if color then
-    return "#" .. to_hex(color)
+  local color = vim.api.nvim_get_hl(0, { name = name })
+  if color["link"] then
+    return get_fg(color["link"])
+  end
+  if color["fg"] then
+    return "#" .. to_hex(color["fg"])
   end
 end
 
 ---@param name string Syntax group name.
 local function get_bg(name)
-  local color = vim.api.nvim_get_hl(0, { name = name })["bg"]
-  if color then
-    return "#" .. to_hex(color)
+  local color = vim.api.nvim_get_hl(0, { name = name })
+  if color["link"] then
+    return get_bg(color["link"])
+  end
+  if color["bg"] then
+    return "#" .. to_hex(color["bg"])
   end
 end
 


### PR DESCRIPTION
New color system doesn't follow highlight links so colorschemes that use links are ignored. This fixes that.

Without fix:
![image](https://github.com/NeogitOrg/neogit/assets/80724403/1ed96f4f-c4e3-4ac0-a8a4-81d6ad0206df)

With fix:
![image](https://github.com/NeogitOrg/neogit/assets/80724403/9dbcb47a-d57f-4b7a-99f0-ecc84da60a80)
