### PR TITLE
Fix: Cherry picking from log buffer/reflog buffer

### DIFF
--- a/lua/neogit/buffers/log_view/init.lua
+++ b/lua/neogit/buffers/log_view/init.lua
@@ -59,6 +59,7 @@ function M:open()
           require("neogit.popups.commit").create { commit = stack[#stack].options.oid }
         end,
         ["v"] = function()
+          print("Multiple commits not yet implimented")
           -- local commits = util.filter_map(
           --   self.buffer.ui:get_component_stack_in_linewise_selection(),
           --   function(c)
@@ -68,8 +69,7 @@ function M:open()
           --   end
           -- )
           --
-          print("Multiple commits not yet implimented")
-          -- RevertPopup.create(commits)
+          -- RevertPopup.create { commits = util.reverse(commits) }
         end,
       },
       n = {

--- a/lua/neogit/buffers/reflog_view/init.lua
+++ b/lua/neogit/buffers/reflog_view/init.lua
@@ -55,6 +55,7 @@ function M:open()
           require("neogit.popups.commit").create { commit = stack[#stack].options.oid }
         end,
         ["v"] = function()
+          print("Multiple commits not yet implimented")
           -- local commits = util.filter_map(
           --   self.buffer.ui:get_component_stack_in_linewise_selection(),
           --   function(c)
@@ -63,9 +64,8 @@ function M:open()
           --     end
           --   end
           -- )
-
-          print("Multiple commits not yet implimented")
-          -- RevertPopup.create(commits)
+          --
+          -- RevertPopup.create { commits = util.reverse(commits) }
         end,
       },
       n = {

--- a/lua/neogit/popups/cherry_pick/actions.lua
+++ b/lua/neogit/popups/cherry_pick/actions.lua
@@ -2,7 +2,6 @@ local M = {}
 
 local a = require("plenary.async")
 local git = require("neogit.lib.git")
-local util = require("neogit.lib.util")
 local CommitSelectViewBuffer = require("neogit.buffers.commit_select_view")
 
 ---@param popup any
@@ -10,9 +9,7 @@ local CommitSelectViewBuffer = require("neogit.buffers.commit_select_view")
 local function get_commits(popup)
   local commits
   if popup.state.env.commits[1] then
-    commits = util.map(popup.state.env.commits, function(c)
-      return c.oid
-    end)
+    commits = popup.state.env.commits
   else
     commits = CommitSelectViewBuffer.new(git.log.list { "--max-count=256" }):open_async()
   end

--- a/lua/neogit/popups/init.lua
+++ b/lua/neogit/popups/init.lua
@@ -1,3 +1,4 @@
+local util = require("neogit.lib.util")
 local M = {}
 
 ---@param name string
@@ -54,7 +55,10 @@ function M.mappings_table()
       {
         "nv",
         M.open("cherry_pick", function(f)
-          f { commits = require("neogit.status").get_selected_commits() }
+          local commits = util.filter_map(require("neogit.status").get_selected_commits(), function(c)
+            return c.oid
+          end)
+          f { commits = util.reverse(commits) }
         end),
       },
     },
@@ -64,7 +68,10 @@ function M.mappings_table()
       {
         "nv",
         M.open("branch", function(f)
-          f { revisions = require("neogit.status").get_selected_commits() }
+          local commits = util.filter_map(require("neogit.status").get_selected_commits(), function(c)
+            return c.oid
+          end)
+          f { revisions = commits }
         end),
       },
     },
@@ -73,9 +80,15 @@ function M.mappings_table()
     {
       "RevertPopup",
       "Revert",
-      M.open("revert", function(f)
-        f { commits = require("neogit.status").get_selected_commits() }
-      end),
+      {
+        "nv",
+        M.open("revert", function(f)
+          local commits = util.filter_map(require("neogit.status").get_selected_commits(), function(c)
+            return c.oid
+          end)
+          f { commits = util.reverse(commits) }
+        end),
+      },
     },
     { "RemotePopup", "Remote", M.open("remote") },
     {

--- a/lua/neogit/popups/revert/actions.lua
+++ b/lua/neogit/popups/revert/actions.lua
@@ -2,7 +2,6 @@ local M = {}
 
 local a = require("plenary.async")
 local git = require("neogit.lib.git")
-local util = require("neogit.lib.util")
 local CommitSelectViewBuffer = require("neogit.buffers.commit_select_view")
 
 ---@param popup any
@@ -10,14 +9,11 @@ local CommitSelectViewBuffer = require("neogit.buffers.commit_select_view")
 local function get_commits(popup)
   local commits
   if popup.state.env.commits[1] then
-    commits = util.map(popup.state.env.commits, function(c)
-      return c.oid
-    end)
+    commits = popup.state.env.commits
   else
     commits = CommitSelectViewBuffer.new(git.log.list { "--max-count=256" }):open_async()
   end
 
-  a.util.scheduler()
   return commits or {}
 end
 


### PR DESCRIPTION
wasn't working because of a type mismatch. The `commits` table was expecting commit objects, whereas we were passing strings.

Update everything to just pass strings.