### PR TITLE
fix: When over a commit, it can be checked out via branch/revisions

### DIFF
--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -63,10 +63,7 @@ M.spin_out_branch = operation("spin_out_branch", function()
 end)
 
 M.checkout_branch_revision = operation("checkout_branch_revision", function(popup)
-  local revisions = util.map(popup.state.env.revisions, function(rev)
-    return rev.oid
-  end)
-  local options = util.merge(revisions, git.branch.get_all_branches())
+  local options = util.merge(popup.state.env.revisions, git.branch.get_all_branches())
   local selected_branch = FuzzyFinderBuffer.new(options):open_async()
   if not selected_branch then
     return


### PR DESCRIPTION
Oops. Can't get `oid` of string.