### PR TITLE
fix: fixes repo not found when special chars in cwd

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -480,7 +480,7 @@ local git_is_repository_sync = function(cwd)
   if not cwd then
     vim.fn.system("git rev-parse --is-inside-work-tree")
   else
-    vim.fn.system(string.format("git -C \"%s\" rev-parse --is-inside-work-tree", cwd))
+    vim.fn.system(string.format("git -C %q rev-parse --is-inside-work-tree", cwd))
   end
 
   return vim.v.shell_error == 0

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -480,7 +480,7 @@ local git_is_repository_sync = function(cwd)
   if not cwd then
     vim.fn.system("git rev-parse --is-inside-work-tree")
   else
-    vim.fn.system(string.format("git -C %s rev-parse --is-inside-work-tree", cwd))
+    vim.fn.system(string.format("git -C \"%s\" rev-parse --is-inside-work-tree", cwd))
   end
 
   return vim.v.shell_error == 0


### PR DESCRIPTION
This fixes the error where Neogit thinks you're not inside a git repo when invoking it while nvim's CWD it set to any path with special characters in it.

Quoting the interpolated string in `string.format` does the trick.

Fixes #736