### PR TITLE
fix: #745 allow functions in status mappings

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -2,5 +2,11 @@
     "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
     "Lua.diagnostics.disable": [
         "redefined-local"
+    ],
+    "diagnostics.globals": [
+        "vim",
+        "it",
+        "describe",
+        "before_each"
     ]
 }

--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -37,7 +37,7 @@ local setup = function(opts)
   require("neogit.autocmds").setup()
 end
 
----@param opts OpenOpts
+---@param opts OpenOpts|nil
 local open = function(opts)
   opts = opts or {}
 

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -40,19 +40,19 @@ end
 ---@field folded boolean Whether or not this section should be shown by default
 
 ---@class NeogitConfigSections
----@field untracked NeogitConfigSection
----@field unstaged NeogitConfigSection
----@field staged NeogitConfigSection
----@field stashes NeogitConfigSection
----@field unpulled_upstream NeogitConfigSection
----@field unmerged_upstream NeogitConfigSection
----@field unpulled_pushRemote NeogitConfigSection
----@field unmerged_pushRemote NeogitConfigSection
----@field recent NeogitConfigSection
----@field rebase NeogitConfigSection
+---@field untracked NeogitConfigSection|nil
+---@field unstaged NeogitConfigSection|nil
+---@field staged NeogitConfigSection|nil
+---@field stashes NeogitConfigSection|nil
+---@field unpulled_upstream NeogitConfigSection|nil
+---@field unmerged_upstream NeogitConfigSection|nil
+---@field unpulled_pushRemote NeogitConfigSection|nil
+---@field unmerged_pushRemote NeogitConfigSection|nil
+---@field recent NeogitConfigSection|nil
+---@field rebase NeogitConfigSection|nil
 
 ---@alias NeogitConfigMappingsFinder "Select" | "Close" | "Next" | "Previous" | "MultiselectToggleNext" | "MultiselectTogglePrevious" | "NOP" | false
----@alias NeogitConfigMappingsStatus "Close" | "InitRepo" | "Depth1" | "Depth2" | "Depth3" | "Depth4" | "Toggle" | "Discard" | "Stage" | "StageUnstaged" | "StageAll" | "Unstage" | "UnstageStaged" | "DiffAtFile" | "CommandHistory" | "Console" | "RefreshBuffer" | "GoToFile" | "VSplitOpen" | "SplitOpen" | "TabOpen" | "HelpPopup" | "DiffPopup" | "PullPopup" | "RebasePopup" | "MergePopup" | "PushPopup" | "CommitPopup" | "LogPopup" | "RevertPopup" | "StashPopup" | "CherryPickPopup" | "BranchPopup" | "FetchPopup" | "ResetPopup" | "RemotePopup" | "GoToPreviousHunkHeader" | "GoToNextHunkHeader" | false
+---@alias NeogitConfigMappingsStatus "Close" | "InitRepo" | "Depth1" | "Depth2" | "Depth3" | "Depth4" | "Toggle" | "Discard" | "Stage" | "StageUnstaged" | "StageAll" | "Unstage" | "UnstageStaged" | "DiffAtFile" | "CommandHistory" | "Console" | "RefreshBuffer" | "GoToFile" | "VSplitOpen" | "SplitOpen" | "TabOpen" | "HelpPopup" | "DiffPopup" | "PullPopup" | "RebasePopup" | "MergePopup" | "PushPopup" | "CommitPopup" | "LogPopup" | "RevertPopup" | "StashPopup" | "CherryPickPopup" | "BranchPopup" | "FetchPopup" | "ResetPopup" | "RemotePopup" | "GoToPreviousHunkHeader" | "GoToNextHunkHeader" | false | fun()
 
 ---@class NeogitConfigMappings Consult the config file or documentation for values
 ---@field finder? { [string]: NeogitConfigMappingsFinder } A dictionary that uses finder commands to set multiple keybinds
@@ -483,9 +483,13 @@ function M.validate_config()
       for key, command in pairs(config.mappings.status) do
         if
           validate_type(key, "mappings.status -> " .. vim.inspect(key), "string")
-          and validate_type(command, string.format("mappings.status['%s']", key), { "string", "boolean" })
+          and validate_type(
+            command,
+            string.format("mappings.status['%s']", key),
+            { "string", "boolean", "function" }
+          )
         then
-          if not vim.tbl_contains(valid_status_commands, command) then
+          if type(command) == "string" and not vim.tbl_contains(valid_status_commands, command) then
             local valid_status_commands = util.map(valid_status_commands, function(command)
               return vim.inspect(command)
             end)

--- a/tests/specs/neogit/config_spec.lua
+++ b/tests/specs/neogit/config_spec.lua
@@ -549,6 +549,13 @@ describe("Neogit config", function()
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
       end)
 
+      it("should return valid when a command mappings.status is a function", function()
+        config.values.mappings.status["c"] = function()
+          print("Well hello there :)")
+        end
+        assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
+      end)
+
       it("should return valid when a command mappings.finder is a boolean", function()
         config.values.mappings.finder["c"] = false
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)


### PR DESCRIPTION
This also fixes the type definitions to allow specifying an incomplete `status = {  }`