### PR TITLE
Refactor Actions

### DIFF
--- a/lua/neogit/client.lua
+++ b/lua/neogit/client.lua
@@ -103,9 +103,6 @@ function M.wrap(cmd, opts)
   else
     notif.create(opts.msg.fail)
   end
-
-  a.util.scheduler()
-  require("neogit.status").refresh(true, opts.refresh)
 end
 
 return M

--- a/lua/neogit/lib/git/rebase.lua
+++ b/lua/neogit/lib/git/rebase.lua
@@ -22,9 +22,6 @@ function M.rebase_interactive(commit, args)
   else
     notif.create("Rebased successfully", vim.log.levels.INFO)
   end
-  a.util.scheduler()
-  local status = require("neogit.status")
-  status.refresh(true, "rebase_interactive")
 end
 
 function M.rebase_onto(branch, args)

--- a/lua/neogit/lib/popup/builder.lua
+++ b/lua/neogit/lib/popup/builder.lua
@@ -267,10 +267,25 @@ function M:action(keys, description, callback)
     self.state.keys[key] = true
   end
 
+  local callback_fn
+  if callback then
+    callback_fn = a.void(function(popup)
+      local cb = function()
+        callback(popup)
+      end
+
+      local refresh = function()
+        require("neogit.status").refresh(true, "action")
+      end
+
+      a.run(cb, refresh)
+    end)
+  end
+
   table.insert(self.state.actions[#self.state.actions], {
     keys = keys,
     description = description,
-    callback = callback and a.void(callback) or nil,
+    callback = callback_fn,
   })
 
   return self

--- a/lua/neogit/lib/popup/builder.lua
+++ b/lua/neogit/lib/popup/builder.lua
@@ -275,7 +275,7 @@ function M:action(keys, description, callback)
       end
 
       local refresh = function()
-        require("neogit.status").refresh(true, "action")
+        require("neogit.status").dispatch_refresh(true, "action")
       end
 
       a.run(cb, refresh)

--- a/lua/neogit/lib/popup/init.lua
+++ b/lua/neogit/lib/popup/init.lua
@@ -512,11 +512,8 @@ function M:show()
         for _, key in ipairs(action.keys) do
           mappings.n[key] = function()
             logger.debug(string.format("[POPUP]: Invoking action '%s' of %s", key, self.state.name))
-            local ret = action.callback(self)
+            action.callback(self)
             self:close()
-            if type(ret) == "function" then
-              ret()
-            end
           end
         end
       else

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -90,7 +90,6 @@ M.checkout_local_branch = operation("checkout_local_branch", function(popup)
     elseif target then
       git.cli.checkout.branch(target).arg_list(popup:get_arguments()).call_sync()
     end
-
   end
 end)
 
@@ -250,7 +249,6 @@ M.delete_branch = operation("delete_branch", function()
       notif.create(string.format("Deleted branch '%s'", branch_name), vim.log.levels.INFO)
     end
   end
-
 end)
 
 return M

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-local status = require("neogit.status")
 local git = require("neogit.lib.git")
 local input = require("neogit.lib.input")
 local util = require("neogit.lib.util")
@@ -54,12 +53,10 @@ end
 
 M.spin_off_branch = operation("spin_off_branch", function()
   spin_off_branch(true)
-  status.refresh(true, "spin_off_branch")
 end)
 
 M.spin_out_branch = operation("spin_out_branch", function()
   spin_off_branch(false)
-  status.refresh(true, "spin_out_branch")
 end)
 
 M.checkout_branch_revision = operation("checkout_branch_revision", function(popup)
@@ -71,7 +68,6 @@ M.checkout_branch_revision = operation("checkout_branch_revision", function(popu
   end
 
   git.cli.checkout.branch(selected_branch).arg_list(popup:get_arguments()).call_sync():trim()
-  status.refresh(true, "checkout_branch")
 end)
 
 M.checkout_local_branch = operation("checkout_local_branch", function(popup)
@@ -95,7 +91,6 @@ M.checkout_local_branch = operation("checkout_local_branch", function(popup)
       git.cli.checkout.branch(target).arg_list(popup:get_arguments()).call_sync()
     end
 
-    status.refresh(true, "branch_checkout")
   end
 end)
 
@@ -106,7 +101,6 @@ M.checkout_recent_branch = operation("checkout_recent_branch", function(popup)
   end
 
   git.cli.checkout.branch(selected_branch).arg_list(popup:get_arguments()).call_sync():trim()
-  status.refresh(true, "checkout_recent_branch")
 end)
 
 M.checkout_create_branch = operation("checkout_create_branch", function()
@@ -128,7 +122,6 @@ M.checkout_create_branch = operation("checkout_create_branch", function()
   end
 
   git.cli.checkout.new_branch_with_start_point(name, base_branch).call_sync()
-  status.refresh(true, "branch_create")
 end)
 
 M.create_branch = operation("create_branch", function()
@@ -139,7 +132,6 @@ M.create_branch = operation("create_branch", function()
 
   name, _ = name:gsub("%s", "-")
   git.branch.create(name)
-  status.refresh(true, "create_branch")
 end)
 
 M.configure_branch = operation("configure_branch", function()
@@ -170,7 +162,6 @@ M.rename_branch = operation("rename_branch", function()
 
   new_name, _ = new_name:gsub("%s", "-")
   git.cli.branch.move.args(selected_branch, new_name).call_sync():trim()
-  status.refresh(true, "rename_branch")
 end)
 
 M.reset_branch = operation("reset_branch", function()
@@ -199,7 +190,6 @@ M.reset_branch = operation("reset_branch", function()
   git.log.update_ref(git.branch.current_full_name(), to)
 
   notif.create(string.format("Reset '%s' to '%s'", current, to), vim.log.levels.INFO)
-  status.refresh(true, "reset_branch")
 end)
 
 M.delete_branch = operation("delete_branch", function()
@@ -261,7 +251,6 @@ M.delete_branch = operation("delete_branch", function()
     end
   end
 
-  status.refresh(true, "delete_branch")
 end)
 
 return M

--- a/lua/neogit/popups/cherry_pick/actions.lua
+++ b/lua/neogit/popups/cherry_pick/actions.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-local a = require("plenary.async")
 local git = require("neogit.lib.git")
 local CommitSelectViewBuffer = require("neogit.buffers.commit_select_view")
 
@@ -24,8 +23,6 @@ function M.pick(popup)
   end
 
   git.cherry_pick.pick(commits, popup:get_arguments())
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "cherry_pick_pick")
 end
 
 function M.apply(popup)
@@ -34,29 +31,19 @@ function M.apply(popup)
     return
   end
 
-  a.util.scheduler()
   git.cherry_pick.apply(commits, popup:get_arguments())
-
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "cherry_pick_apply")
 end
 
 function M.continue()
   git.cherry_pick.continue()
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "cherry_pick_continue")
 end
 
 function M.skip()
   git.cherry_pick.skip()
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "cherry_pick_skip")
 end
 
 function M.abort()
   git.cherry_pick.abort()
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "cherry_pick_abort")
 end
 
 return M

--- a/lua/neogit/popups/fetch/actions.lua
+++ b/lua/neogit/popups/fetch/actions.lua
@@ -4,7 +4,6 @@ local a = require("plenary.async")
 local git = require("neogit.lib.git")
 local logger = require("neogit.logger")
 local notif = require("neogit.lib.notification")
-local status = require("neogit.status")
 local util = require("neogit.lib.util")
 
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
@@ -21,7 +20,6 @@ local function fetch_from(name, remote, branch, args)
     a.util.scheduler()
     notif.create("Fetched from " .. name)
     logger.debug("Fetched from " .. name)
-    status.refresh(true, "fetch_from")
     vim.api.nvim_exec_autocmds("User", { pattern = "NeogitFetchComplete", modeline = false })
   else
     logger.error("Failed to fetch from " .. name)
@@ -119,7 +117,6 @@ end
 function M.fetch_submodules(_)
   notif.create("Fetching submodules")
   git.cli.fetch.recurse_submodules().verbose().jobs(4).call()
-  status.refresh(true, "fetch_submodules")
 end
 
 function M.set_variables()

--- a/lua/neogit/popups/merge/actions.lua
+++ b/lua/neogit/popups/merge/actions.lua
@@ -3,8 +3,6 @@ local M = {}
 local git = require("neogit.lib.git")
 local input = require("neogit.lib.input")
 
-local a = require("plenary.async")
-
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 
 function M.in_merge()
@@ -13,8 +11,6 @@ end
 
 function M.commit()
   git.merge.continue()
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "merge_continue")
 end
 
 function M.abort()
@@ -23,8 +19,6 @@ function M.abort()
   end
 
   git.merge.abort()
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "merge_abort")
 end
 
 function M.merge(popup)
@@ -34,8 +28,6 @@ function M.merge(popup)
   end
 
   git.merge.merge(branch, popup:get_arguments())
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "merge")
 end
 
 return M

--- a/lua/neogit/popups/pull/actions.lua
+++ b/lua/neogit/popups/pull/actions.lua
@@ -2,7 +2,6 @@ local a = require("plenary.async")
 local git = require("neogit.lib.git")
 local logger = require("neogit.logger")
 local notif = require("neogit.lib.notification")
-local status = require("neogit.status")
 
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 
@@ -26,7 +25,6 @@ local function pull_from(args, remote, branch, opts)
     a.util.scheduler()
     notif.create("Pulled from " .. name)
     logger.debug("Pulled from " .. name)
-    status.refresh(true, "pull_from")
     vim.api.nvim_exec_autocmds("User", { pattern = "NeogitPullComplete", modeline = false })
   else
     logger.error("Failed to pull from " .. name)

--- a/lua/neogit/popups/push/actions.lua
+++ b/lua/neogit/popups/push/actions.lua
@@ -2,7 +2,6 @@ local a = require("plenary.async")
 local git = require("neogit.lib.git")
 local logger = require("neogit.logger")
 local notif = require("neogit.lib.notification")
-local status = require("neogit.status")
 
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 
@@ -26,7 +25,6 @@ local function push_to(args, remote, branch, opts)
     a.util.scheduler()
     logger.error("Pushed to " .. name)
     notif.create("Pushed to " .. name)
-    status.refresh(true, "push_to")
     vim.api.nvim_exec_autocmds("User", { pattern = "NeogitPushComplete", modeline = false })
   else
     logger.error("Failed to push to " .. name)

--- a/lua/neogit/popups/rebase/actions.lua
+++ b/lua/neogit/popups/rebase/actions.lua
@@ -1,7 +1,5 @@
-local a = require("plenary.async")
 local git = require("neogit.lib.git")
 local input = require("neogit.lib.input")
-local status = require("neogit.status")
 
 local CommitSelectViewBuffer = require("neogit.buffers.commit_select_view")
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
@@ -23,8 +21,6 @@ end
 
 function M.onto_base(popup)
   git.rebase.rebase_onto(M.base_branch(), popup:get_arguments())
-  a.util.scheduler()
-  status.refresh(true, "rebase_master")
 end
 
 function M.onto_pushRemote(popup)
@@ -38,9 +34,6 @@ function M.onto_pushRemote(popup)
       string.format("refs/remotes/%s/%s", pushRemote, git.branch.current()),
       popup:get_arguments()
     )
-
-    a.util.scheduler()
-    status.refresh(true, "rebase_pushremote")
   end
 end
 
@@ -58,16 +51,12 @@ function M.onto_upstream(popup)
   end
 
   git.rebase.rebase_onto(upstream, popup:get_arguments())
-  a.util.scheduler()
-  status.refresh(true, "rebase_upstream")
 end
 
 function M.onto_elsewhere(popup)
   local target = FuzzyFinderBuffer.new(git.branch.get_all_branches()):open_async()
   if target then
     git.rebase.rebase_onto(target, popup:get_arguments())
-    a.util.scheduler()
-    status.refresh(true, "rebase_elsewhere")
   end
 end
 
@@ -81,29 +70,21 @@ function M.interactively(popup)
 
   if commit then
     git.rebase.rebase_interactive(commit, popup:get_arguments())
-    a.util.scheduler()
-    status.refresh(true, "rebase_interactive")
   end
 end
 
 function M.continue()
   git.rebase.continue()
-  a.util.scheduler()
-  status.refresh(true, "rebase_continue")
 end
 
 function M.skip()
   git.rebase.skip()
-  a.util.scheduler()
-  status.refresh(true, "rebase_skip")
 end
 
 -- TODO: Extract to rebase lib?
 function M.abort()
   if input.get_confirmation("Abort rebase?", { values = { "&Yes", "&No" }, default = 2 }) then
     git.cli.rebase.abort.call_sync():trim()
-    a.util.scheduler()
-    status.refresh(true, "rebase_abort")
   end
 end
 

--- a/lua/neogit/popups/remote/actions.lua
+++ b/lua/neogit/popups/remote/actions.lua
@@ -1,10 +1,8 @@
 local M = {}
 
-local a = require("plenary.async")
 local git = require("neogit.lib.git")
 local input = require("neogit.lib.input")
 local notification = require("neogit.lib.notification")
-local status = require("neogit.status")
 
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 local RemoteConfigPopup = require("neogit.popups.remote_config")
@@ -63,9 +61,7 @@ function M.rename(_)
   end
 
   git.remote.rename(selected_remote, new_name)
-  a.util.scheduler()
   notification.create("Renamed remote " .. selected_remote .. " to " .. new_name)
-  status.refresh(true, "rename_remote")
 end
 
 function M.remove(_)
@@ -75,9 +71,7 @@ function M.remove(_)
   end
 
   git.remote.remove(selected_remote)
-  a.util.scheduler()
   notification.create("Removed remote " .. selected_remote)
-  status.refresh(true, "remove_remote")
 end
 
 function M.configure(_)
@@ -97,8 +91,6 @@ function M.prune_branches(_)
 
   notification.create("Pruning remote " .. selected_remote)
   git.remote.prune(selected_remote)
-  a.util.scheduler()
-  status.refresh(true, "prune_remote")
 end
 
 -- https://github.com/magit/magit/blob/main/lisp/magit-remote.el#L159

--- a/lua/neogit/popups/reset/actions.lua
+++ b/lua/neogit/popups/reset/actions.lua
@@ -1,6 +1,5 @@
 local a = require("plenary.async")
 local git = require("neogit.lib.git")
-local status = require("neogit.status")
 local util = require("neogit.lib.util")
 
 local CommitSelectViewBuffer = require("neogit.buffers.commit_select_view")
@@ -20,8 +19,6 @@ local function reset(type, popup)
   end
 
   git.reset[type](commit)
-  a.util.scheduler()
-  status.refresh(true, "reset_" .. type)
 end
 
 function M.mixed(popup)
@@ -72,8 +69,6 @@ function M.a_file(popup)
   end
 
   git.reset.file(commit, files)
-  a.util.scheduler()
-  status.refresh(true, "reset_file")
 end
 
 return M

--- a/lua/neogit/popups/revert/actions.lua
+++ b/lua/neogit/popups/revert/actions.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-local a = require("plenary.async")
 local git = require("neogit.lib.git")
 local client = require("neogit.client")
 local notif = require("neogit.lib.notification")
@@ -59,9 +58,6 @@ function M.commits(popup)
       fail = "Couldn't revert",
     },
   })
-
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "revert_commits")
 end
 
 function M.changes(popup)
@@ -71,26 +67,18 @@ function M.changes(popup)
   end
 
   git.revert.commits(commits, popup:get_arguments())
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "revert_changes")
 end
 
 function M.continue()
   git.revert.continue()
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "revert_continue")
 end
 
 function M.skip()
   git.revert.skip()
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "revert_skip")
 end
 
 function M.abort()
   git.revert.abort()
-  a.util.scheduler()
-  require("neogit.status").refresh(true, "revert_abort")
 end
 
 return M

--- a/lua/neogit/popups/stash/actions.lua
+++ b/lua/neogit/popups/stash/actions.lua
@@ -1,5 +1,3 @@
-local a = require("plenary.async")
-local status = require("neogit.status")
 local git = require("neogit.lib.git")
 
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
@@ -8,14 +6,10 @@ local M = {}
 
 function M.both(popup)
   git.stash.stash_all(popup:get_arguments())
-  a.util.scheduler()
-  status.refresh(true, "stash_both")
 end
 
 function M.index(popup)
   git.stash.stash_index(popup:get_arguments())
-  a.util.scheduler()
-  status.refresh(true, "stash_index")
 end
 
 function M.push(popup)
@@ -25,8 +19,6 @@ function M.push(popup)
   end
 
   git.stash.push(popup:get_arguments(), files)
-  a.util.scheduler()
-  status.refresh(true, "stash_push")
 end
 
 local function use(action, stash)
@@ -45,8 +37,6 @@ local function use(action, stash)
 
   if name then
     git.stash[action](name)
-    a.util.scheduler()
-    status.refresh(true, "stash_" .. action)
   end
 end
 


### PR DESCRIPTION
Remove the need to call `status.refresh()` from every single action. Instead, wrap the action function and run it with `status.dispatch_refresh()` as a callback.

This is a setup step for the file watcher.

