### PR TITLE
fix: set `signcolumns` to 'auto' when disable_signs is false to avoid unnecessary statuscolumn

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -486,7 +486,7 @@ function Buffer.create(config)
     -- If signs are not disabled, avoid overrided by user settings
     buffer:call(function()
       if not config.disable_signs then
-        vim.wo.signcolumn = "yes"
+        vim.wo.signcolumn = "auto"
       end
     end)
   end)


### PR DESCRIPTION
When setting `signcolumns` to `yes`, the buffers with filetype `NeogitCommitMessage` and `NeogitCommitMessage` will also have 1 column in the left margin indicating a signcolumn. However, we shouldn't have signcolumns for those buffers. We only need to have signcolumns for the `NeogitStatus` buffer. Setting the option to `auto` will automatically handle the situation.