### PR TITLE
feat: Add basic fzf-lua integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Here's an example spec for [Lazy](https://github.com/folke/lazy.nvim), but you'r
     "nvim-lua/plenary.nvim",         -- required
     "nvim-telescope/telescope.nvim", -- optional
     "sindrets/diffview.nvim",        -- optional
+    "ibhagwan/fzf-lua",              -- optional
   },
   config = true
 }
@@ -141,6 +142,11 @@ neogit.setup {
     --
     -- Requires you to have `sindrets/diffview.nvim` installed.
     diffview = nil,
+
+    -- If enabled, uses fzf-lua for menu selection. If the telescope integration
+    -- is also selected then telescope is used instead
+    -- Requires you to have `ibhagwan/fzf-lua` installed.
+    fzf_lua = nil,
   },
   sections = {
     -- Reverting/Cherry Picking

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -86,7 +86,7 @@ end
 ---@field preview_buffer? NeogitConfigPopup Preview options
 ---@field popup? NeogitConfigPopup Set the default way of opening popups
 ---@field signs? NeogitConfigSigns Signs used for toggled regions
----@field integrations? { diffview: boolean, telescope: boolean } Which integrations to enable
+---@field integrations? { diffview: boolean, telescope: boolean, fzf_lua: boolean } Which integrations to enable
 ---@field sections? NeogitConfigSections
 ---@field ignored_settings? string[] Settings to never persist, format: "Filetype--cli-value", i.e. "NeogitCommitPopup--author"
 ---@field mappings? NeogitConfigMappings
@@ -151,6 +151,7 @@ function M.get_default_values()
     integrations = {
       telescope = nil,
       diffview = nil,
+      fzf_lua = nil,
     },
     sections = {
       sequencer = {
@@ -383,7 +384,7 @@ function M.validate_config()
   end
 
   local function validate_integrations()
-    local valid_integrations = { "diffview", "telescope" }
+    local valid_integrations = { "diffview", "telescope", "fzf_lua" }
     if not validate_type(config.integrations, "integrations", "table") or #config.integrations == 0 then
       return
     end


### PR DESCRIPTION
Adds the basic popup integration for fzf-lua. I mapped a majority of the telescope options to the fzf-lua equivalents as to not add more custom options.
Also if both telescope and fzf-lua integrations are enabled, the telescope integration takes precedence.

Let me know if I need to fix anything or if I'm missing anything.