### PR TITLE
feat: Add highlighting to commit based on signature flag

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -279,6 +279,9 @@ NeogitGraphCyan
 NeogitGraphCyanBold
 NeogitGraphWhite
 NeogitGraphWhiteBold
+NeogitGraphGray
+NeogitGraphBoldGray
+NeogitGraphOrange
 
 POPUPS
 NeogitPopupSectionTitle    Applied to all section headers

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -88,6 +88,25 @@ local function build_graph(graph)
   end
 end
 
+-- - '%G?': show "G" for a good (valid) signature,
+--   "B" for a bad signature,
+--   "U" for a good signature with unknown validity,
+--   "X" for a good signature that has expired,
+--   "Y" for a good signature made by an expired key,
+--   "R" for a good signature made by a revoked key,
+--   "E" if the signature cannot be checked (e.g. missing key)
+--   and "N" for no signature
+local highlight_for_signature = {
+  G = "NeogitGraphGreen",
+  B = "NeogitGraphRed",
+  U = "NeogitGraphBoldBlue",
+  X = "NeogitGraphOrange",
+  Y = "NeogitGraphOrange",
+  R = "NeogitGraphRed",
+  E = "NeogitGraphBlue",
+  N = "NeogitGraphGray",
+}
+
 M.CommitEntry = Component.new(function(commit, args)
   local ref = {}
   if commit.ref_name ~= "" then
@@ -169,13 +188,10 @@ M.CommitEntry = Component.new(function(commit, args)
 
   return col({
     row(
-      util.merge(
-        { text(commit.oid:sub(1, 7), { highlight = "Comment" }), text(" ") },
-        graph,
-        { text(" ") },
-        ref,
-        { text(commit.description[1]) }
-      ),
+      util.merge({
+        text(commit.oid:sub(1, 7), { highlight = highlight_for_signature[commit.signature_code] }),
+        text(" "),
+      }, graph, { text(" ") }, ref, { text(commit.description[1]) }),
       {
         virtual_text = {
           { " ", "Constant" },

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -159,7 +159,7 @@ local function parse(raw)
 end
 
 local function make_commit(entry, graph)
-  local hash, subject, author_name, rel_date, ref_name, author_date, committer_name, committer_date, committer_email, author_email, body =
+  local hash, subject, author_name, rel_date, ref_name, author_date, committer_name, committer_date, committer_email, author_email, body, signature_code =
     unpack(entry)
 
   if rel_date then
@@ -179,6 +179,7 @@ local function make_commit(entry, graph)
     committer_name = committer_name,
     committer_email = committer_email,
     body = body,
+    signature_code = signature_code,
     -- TODO: Remove below here
     hash = hash,
     message = subject,
@@ -236,6 +237,7 @@ local format = table.concat({
   "%ce", -- Committer Email
   "%ae", -- Author Email
   "%b", -- Body
+  "%G?", -- Signature status
   "%x1F", -- Entry delimiter to split on (dec \31)
 }, "%x1E") -- Field delimiter to split on (dec \30)
 

--- a/lua/neogit/lib/hl.lua
+++ b/lua/neogit/lib/hl.lua
@@ -115,6 +115,7 @@ function M.setup()
     NeogitGraphBlue = { fg = palette.blue },
     NeogitGraphPurple = { fg = palette.purple },
     NeogitGraphGray = { fg = palette.grey },
+    NeogitGraphOrange = { fg = palette.orange },
     NeogitGraphBoldRed = { fg = palette.red, bold = true },
     NeogitGraphBoldWhite = { fg = palette.white, bold = true },
     NeogitGraphBoldYellow = { fg = palette.yellow, bold = true },


### PR DESCRIPTION
Modifies the log view buffer to highlight the commit based on the status of the commit signature.
I tried mapping the highlight colors from magit but feel free to adjust them.

Still need to add the signature output on the commit details buffer but that one is a bit more messy as I need to record if `--show-signature` was passed in the parent BufferWindow and pass it down to the CommitDetailView to be used in `git show`. I'll work on that in another PR 🤔 .

Solves half of #784 
