### PR TITLE
feat: Show signature details in commit detail view

### DIFF
--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -15,6 +15,7 @@ local M = {
 -- @class CommitViewBuffer
 -- @field is_open whether the buffer is currently shown
 -- @field commit_info CommitInfo
+-- @field commit_signature table|nil
 -- @field commit_overview CommitOverview
 -- @field buffer Buffer
 -- @see CommitInfo
@@ -30,13 +31,13 @@ function M.new(commit_id, notify)
     local notif = require("neogit.lib.notification")
     notification = notif.create("Parsing commit...")
   end
-
   local instance = {
     is_open = false,
     commit_info = log.parse(cli.show.format("fuller").args(commit_id).call_sync().stdout)[1],
     commit_overview = parser.parse_commit_overview(
       cli.show.stat.oneline.args(commit_id).call_sync():trim().stdout
     ),
+    commit_signature = log.verify_commit(commit_id),
     buffer = nil,
   }
 
@@ -168,7 +169,7 @@ function M:open()
       },
     },
     render = function()
-      return ui.CommitView(self.commit_info, self.commit_overview)
+      return ui.CommitView(self.commit_info, self.commit_overview, self.commit_signature)
     end,
   }
 end

--- a/lua/neogit/buffers/commit_view/ui.lua
+++ b/lua/neogit/buffers/commit_view/ui.lua
@@ -37,12 +37,15 @@ function M.CommitHeader(info)
   }
 end
 
-function M.CommitView(info, overview)
+function M.CommitView(info, overview, signature_block)
+  local hide_signature = vim.tbl_isempty(signature_block)
   return {
     M.CommitHeader(info),
     text(""),
     col(map(info.description, text), { sign = "NeogitCommitViewDescription", tag = "Description" }),
     text(""),
+    col(map(signature_block or {}, text), { tag = "Signature", hidden = hide_signature }),
+    text("", { hidden = hide_signature }),
     text(overview.summary),
     col(map(overview.files, M.OverviewFile), { tag = "OverviewFileList" }),
     text(""),

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -475,6 +475,7 @@ local configurations = {
       abort = "--abort",
     },
   },
+  ["verify-commit"] = config {},
 }
 
 -- TODO: Consider returning a Path object, since consumers of this function tend to need that anyways.

--- a/lua/neogit/popups/log/actions.lua
+++ b/lua/neogit/popups/log/actions.lua
@@ -13,10 +13,16 @@ local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 local function maybe_graph(popup)
   local args = popup:get_internal_arguments()
   if args.graph then
-    return git.log.graph(popup:get_arguments())
+    local external_args = popup:get_arguments()
+    util.remove_item_from_table(external_args, "--show-signature")
+    return git.log.graph(external_args)
   end
 end
 
+--- Runs `git log` and parses the commits
+---@param popup table Contains the argument list
+---@param extras table|nil
+---@return CommitLogEntry[]
 local function commits(popup, extras)
   return git.log.list(util.merge(popup:get_arguments(), extras or {}), maybe_graph(popup))
 end


### PR DESCRIPTION
Modifies log commit detail view to show the signature block when the `--show-signature` flag is passed to the log buffer. When the log commit detail view buffer is opened it will run `git verify-commit` against the hash and record the output.

It might be a bit messy but we have to record if the --show-signature flag was set, then remove the --show-signature flag from the log graph view command and the actual git log command.
Then when we open a commit log from the log list page we need to check if the --show-signature flag was set from the parent git log command and run `git verify-commit` to output the signature.

I tried just parsing the signature lines in the intial `git log` command and store it in the actual commit struct but its difficult to tell where a signature block ends with just string parsing alone.

Second half of #784
