### PR TITLE
feat: Show tag name and distance from head on status page

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -205,6 +205,9 @@ NeogitObjectId              Object's SHA hash
 NeogitStash                 Stash name
 NeogitFold                  Folded text highlight
 NeogitRebaseDone            Current position within rebase
+NeogitTagName               Closest Tag name
+NeogitTagDistance           Number of commits between the tag and HEAD
+
 
 STATUS BUFFER SECTION HEADERS
 NeogitSectionHeader

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -96,6 +96,13 @@ local configurations = {
     },
   },
 
+  describe = config {
+    flags = {
+      long = "--long",
+      tags = "--tags",
+    },
+  },
+
   diff = config {
     flags = {
       cached = "--cached",

--- a/lua/neogit/lib/git/repository.lua
+++ b/lua/neogit/lib/git/repository.lua
@@ -19,7 +19,11 @@ local function empty_state()
     git_root     = root,
     head         = {
       branch = nil,
-      commit_message = nil
+      commit_message = nil,
+      tag = {
+        name = nil,
+        distance = nil,
+      },
     },
     upstream     = {
       branch         = nil,

--- a/lua/neogit/lib/hl.lua
+++ b/lua/neogit/lib/hl.lua
@@ -186,6 +186,8 @@ function M.setup()
     NeogitRebasing = { link = "NeogitSectionHeader" },
     NeogitPicking = { link = "NeogitSectionHeader" },
     NeogitReverting = { link = "NeogitSectionHeader" },
+    NeogitTagName = { fg = palette.yellow },
+    NeogitTagDistance = { fg = palette.cyan }
   }
   -- stylua: ignore end
 

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -208,6 +208,9 @@ local function draw_buffer()
       )
     end
   end
+  if git.repo.head.tag.name then
+    output:append(string.format("Tag:      %s (%s)", git.repo.head.tag.name, git.repo.head.tag.distance))
+  end
 
   output:append("")
 

--- a/syntax/NeogitStatus.vim
+++ b/syntax/NeogitStatus.vim
@@ -27,6 +27,8 @@ syn match NeogitDiffDelete    /.*/                  contained
 syn match NeogitUnmergedInto  /Unmerged into/       contained
 syn match NeogitUnpushedTo    /Unpushed to/         contained
 syn match NeogitUnpulledFrom  /Unpulled from/       contained
+syn match NeogitTagName       /\S\+ /               contained nextgroup=NeogitTagDistance
+syn match NeogitTagDistance   /[0-9]/               contained
 
 syn match NeogitStash         /stash@{[0-9]*}\ze/
 syn match NeogitObjectId      "\v<\x{7,}>"          contains=@NoSpell
@@ -58,5 +60,6 @@ syn region NeogitUnpushedToRegion   start=/^Unpushed to .*/   end=/$/ contains=N
 syn region NeogitUnpulledFromRegion start=/^Unpulled from .*/ end=/$/ contains=NeogitRemote,NeogitUnpulledFrom
 syn region NeogitDiffAddRegion      start=/^+.*$/             end=/$/ contains=NeogitDiffAdd
 syn region NeogitDiffDeleteRegion   start=/^-.*$/             end=/$/ contains=NeogitDiffDelete
+syn region NeogitTagRegion          start=/^Tag: \zs/         end=/$/ contains=NeogitTagName,NeogitTagDistance
 
 let b:current_syntax = 1


### PR DESCRIPTION
Similar to Magit's status page this commit adds the most recent tag name to the status popup with the distance (commits) between the head and tag

Unfortunately lua's pattern matching isn't as complete as I had hoped for so there might be some cases where it fails. When it fails it will just set the tag and distance to nil making it unrendered.