### PR TITLE
fix: replace os.execute with vim.system to prevent stdout from messin…

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -138,7 +138,7 @@ function M.get_default_values()
     },
     commit_view = {
       kind = "vsplit",
-      verify_commit = vim.fn.executable('gpg') == 1,
+      verify_commit = vim.fn.executable("gpg") == 1,
     },
     log_view = {
       kind = "tab",

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -138,7 +138,7 @@ function M.get_default_values()
     },
     commit_view = {
       kind = "vsplit",
-      verify_commit = os.execute("which gpg") == 0,
+      verify_commit = vim.system({ "which", "gpg" }):wait().code == 0,
     },
     log_view = {
       kind = "tab",

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -138,7 +138,7 @@ function M.get_default_values()
     },
     commit_view = {
       kind = "vsplit",
-      verify_commit = vim.system({ "which", "gpg" }):wait().code == 0,
+      verify_commit = vim.fn.executable('gpg') == 1,
     },
     log_view = {
       kind = "tab",


### PR DESCRIPTION
…g up the screen

Stdout from os.execute messes up the screen. This uses vim.system to fix it. This closes #801 .