### PR TITLE
feat: Allow opening commit details from status buffer header lines

### DIFF
--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -8,32 +8,50 @@ local popups = require("neogit.popups")
 
 local api = vim.api
 
+---@class CommitInfo
+---@field oid string Full commit hash
+---@field author_email string
+---@field author_name string
+---@field author_date string
+---@field commit_arg string The commit argument passed to `git show`
+---@field commiter_email string
+---@field commiter_date string
+---@field description table
+
+---@class CommitOverview
+---@field summary string
+---@field files table
+
+--- @class CommitViewBuffer
+--- @field is_open boolean whether the buffer is currently shown
+--- @field commit_info CommitInfo
+--- @field commit_signature table|nil
+--- @field commit_overview CommitOverview
+--- @field buffer Buffer
+--- @field open fun()
+--- @field close fun()
+--- @see CommitInfo
+--- @see Buffer
+--- @see Ui
 local M = {
   instance = nil,
 }
 
--- @class CommitViewBuffer
--- @field is_open whether the buffer is currently shown
--- @field commit_info CommitInfo
--- @field commit_signature table|nil
--- @field commit_overview CommitOverview
--- @field buffer Buffer
--- @see CommitInfo
--- @see Buffer
--- @see Ui
-
 --- Creates a new CommitViewBuffer
--- @param commit_id the id of the commit
--- @return CommitViewBuffer
+--- @param commit_id string the id of the commit/tag
+--- @param notify boolean Should show a notification or not
+--- @return CommitViewBuffer
 function M.new(commit_id, notify)
   local notification
   if notify then
     local notif = require("neogit.lib.notification")
     notification = notif.create("Parsing commit...")
   end
+  local commit_info = log.parse(cli.show.format("fuller").args(commit_id).call_sync().stdout)[1]
+  commit_info.commit_arg = commit_id
   local instance = {
     is_open = false,
-    commit_info = log.parse(cli.show.format("fuller").args(commit_id).call_sync().stdout)[1],
+    commit_info = commit_info,
     commit_overview = parser.parse_commit_overview(
       cli.show.stat.oneline.args(commit_id).call_sync():trim().stdout
     ),
@@ -50,12 +68,15 @@ function M.new(commit_id, notify)
   return instance
 end
 
+--- Closes the CommitViewBuffer
 function M:close()
   self.is_open = false
   self.buffer:close()
   self.buffer = nil
 end
 
+--- Opens the CommitViewBuffer
+--- If already open will close the buffer
 function M:open()
   if M.instance and M.instance.is_open then
     M.instance:close()

--- a/lua/neogit/buffers/commit_view/ui.lua
+++ b/lua/neogit/buffers/commit_view/ui.lua
@@ -22,8 +22,13 @@ function M.OverviewFile(file)
 end
 
 function M.CommitHeader(info)
+  local full_commit = {}
+  if info.oid ~= info.commit_arg then
+    full_commit = row { text(info.commit_arg .. " "), text.highlight("Comment")(info.oid) }
+  end
   return col {
-    text.sign("NeogitCommitViewHeader")("Commit " .. info.oid),
+    text.sign("NeogitCommitViewHeader")("Commit " .. info.commit_arg),
+    full_commit,
     row {
       text.highlight("Comment")("Author:     "),
       text(info.author_name .. " <" .. info.author_email .. ">"),

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -17,6 +17,7 @@ local commit_header_pat = "([| ]*)(%*?)([| ]*)commit (%w+)"
 ---@field committer_email string the email of the committer
 ---@field committer_date string when the committer commited
 ---@field description string a list of lines
+---@field commit_arg string the passed argument of the git command
 ---@field diffs any[]
 
 ---Parses the provided list of lines into a CommitLogEntry

--- a/tests/specs/neogit/popups/remote_spec.lua
+++ b/tests/specs/neogit/popups/remote_spec.lua
@@ -19,7 +19,7 @@ describe("remote popup", function()
     "can add remote",
     in_prepared_repo(function()
       input.values = { "foo", "https://github.com/foo/bar" }
-      act("Ma<cr>")
+      act("Ma")
 
       operations.wait("add_remote")
 
@@ -27,7 +27,7 @@ describe("remote popup", function()
       eq({ "https://github.com/foo/bar" }, lib.git.remote.get_url("foo"))
 
       input.values = { "other", "" }
-      act("Ma<cr>")
+      act("Ma")
 
       operations.wait("add_remote")
 


### PR DESCRIPTION
This commit allows users to open the commit/ref/tag under their cursor for the top 4 header lines (head,upstream,pushRemote,tags) similar to how magit allows user to do the same on the status buffer. Similarly to how magit displays commits in their viewer, the top line now shows the passed argument (commit,ref,tag) used in the git command. Then below that line is the full commit hash of it.  

Had to modify the section table a bit to allow handling sections where there are no files within but it gets the job done.
Maybe it would be a nicer api in the future to define sections with callbacks for when a user performs a select action on instead of having to check the name of the section and perform an action from there.

Like always feel free to point out changes 🙏 . Also should I be posting in the Neogit discussion/development thread for these kind of changes beforehand?