### PR TITLE
feat: Add Tag popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ neogit.setup {
   merge_editor = {
     kind = "split",
   },
+  tag_editor = {
+    kind = "split",
+  },
   preview_buffer = {
     kind = "split",
   },

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -49,6 +49,8 @@ CONTENTS                                                       *neogit_contents*
        • Revert                                           |neogit_revert_popup|
        • Reset                                             |neogit_reset_popup|
        • Stash                                             |neogit_stash_popup|
+       • Tag                                                 |neogit_tag_popup|
+
     7. Buffers                                                 |neogit_buffers|
        • Status                                          |neogit_status_buffer|
        • Log                                                |neogit_log_buffer|
@@ -1007,6 +1009,38 @@ Actions:                                            *neogit_reset_popup_actions*
 Stash Popup                                                 *neogit_stash_popup*
 
 (TODO)
+
+==============================================================================
+Tag Popup                                                     *neogit_tag_popup*
+
+Arguments:                                               *neogit_tag_popup_args*
+  • --force
+    Replace an existing tag with the given name (instead of failing)
+
+  • --annotate
+    Make an unsigned, annotated tag object
+
+  • --sign
+    Make a GPG-signed tag, using the default e-mail address’s key. The default
+    behavior of tag GPG-signing is controlled by `tag.gpgSign` configuration
+    variable if it exists, or disabled otherwise.
+
+  • --local-user
+    Make a GPG-signed tag, using the given key.
+
+Actions:                                              *neogit_tag_popup_actions*
+
+  • Tag                                                         *neogit_tag_tag*
+    Creates a new TAG at specified REV.
+
+  • Release                                                 *neogit_tag_release*
+    (not yet implemented)
+
+  • Delete                                                   *neogit_tag_delete*
+    Deletes one or more tags.
+
+  • Prune                                                     *neogit_tag_prune*
+    Offers to delete tags missing locally from REMOTE, and vice versa.
 
 ==============================================================================
 7. Buffers                                                      *neogit_buffers*

--- a/lua/neogit/buffers/tag_editor.lua
+++ b/lua/neogit/buffers/tag_editor.lua
@@ -1,0 +1,44 @@
+local Buffer = require("neogit.lib.buffer")
+local config = require("neogit.config")
+
+local M = {}
+
+function M.new(filename, on_close)
+  local instance = {
+    filename = filename,
+    on_close = on_close,
+    buffer = nil,
+  }
+
+  setmetatable(instance, { __index = M })
+
+  return instance
+end
+
+function M:open()
+  self.buffer = Buffer.create {
+    name = self.filename,
+    load = true,
+    filetype = "NeogitTagMessage",
+    buftype = "",
+    kind = config.values.tag_editor.kind,
+    modifiable = true,
+    readonly = false,
+    autocmds = {
+      ["BufUnload"] = function()
+        self.on_close()
+        vim.cmd("silent w!")
+        require("neogit.process").defer_show_preview_buffers()
+      end,
+    },
+    mappings = {
+      n = {
+        ["q"] = function(buffer)
+          buffer:close(true)
+        end,
+      },
+    },
+  }
+end
+
+return M

--- a/lua/neogit/client.lua
+++ b/lua/neogit/client.lua
@@ -72,7 +72,7 @@ function M.editor(target, client)
     editor.rebase_editor(target, send_client_quit)
   elseif target:find("COMMIT_EDITMSG$") then
     editor.commit_editor(target, send_client_quit)
-  elseif target:find("MERGE_MSG$") then
+  elseif target:find("MERGE_MSG$") or target:find("TAG_EDITMSG$") then
     editor.merge_editor(target, send_client_quit)
   else
     local notification = require("neogit.lib.notification")
@@ -81,8 +81,17 @@ function M.editor(target, client)
   end
 end
 
+---@class NotifyMsg
+---@field setup string|nil Message to show before running
+---@field success string|nil Message to show when successful
+---@field fail string|nil Message to show when failed
+
+---@class WrapOpts
+---@field autocmd string
+---@field msg NotifyMsg
+
 ---@param cmd any
----@param opts table
+---@param opts WrapOpts
 function M.wrap(cmd, opts)
   local notification = require("neogit.lib.notification")
   local a = require("plenary.async")

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -94,6 +94,7 @@ end
 ---@field rebase_editor? NeogitConfigPopup Rebase editor options
 ---@field reflog_view? NeogitConfigPopup Reflog view options
 ---@field merge_editor? NeogitConfigPopup Merge editor options
+---@field tag_editor? NeogitConfigPopup Tag editor options
 ---@field preview_buffer? NeogitConfigPopup Preview options
 ---@field popup? NeogitConfigPopup Set the default way of opening popups
 ---@field signs? NeogitConfigSigns Signs used for toggled regions
@@ -158,6 +159,9 @@ function M.get_default_values()
       kind = "tab",
     },
     merge_editor = {
+      kind = "split",
+    },
+    tag_editor = {
       kind = "split",
     },
     preview_buffer = {

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -273,6 +273,7 @@ function M.get_default_values()
         ["P"] = "PushPopup",
         ["c"] = "CommitPopup",
         ["i"] = "IgnorePopup",
+        ["t"] = "TagPopup",
         ["l"] = "LogPopup",
         ["v"] = "RevertPopup",
         ["Z"] = "StashPopup",

--- a/lua/neogit/editor.lua
+++ b/lua/neogit/editor.lua
@@ -1,6 +1,7 @@
 local RebaseEditorBuffer = require("neogit.buffers.rebase_editor")
 local CommitEditorBuffer = require("neogit.buffers.commit_editor")
 local MergeEditorBuffer = require("neogit.buffers.merge_editor")
+local TagEditorBuffer = require("neogit.buffers.tag_editor")
 
 local M = {}
 
@@ -14,6 +15,10 @@ end
 
 function M.merge_editor(target, on_unload)
   MergeEditorBuffer.new(target, on_unload):open()
+end
+
+function M.tag_editor(target, on_unload)
+  TagEditorBuffer.new(target, on_unload):open()
 end
 
 return M

--- a/lua/neogit/lib/git.lua
+++ b/lua/neogit/lib/git.lua
@@ -8,6 +8,8 @@ return {
   files = require("neogit.lib.git.files"),
   fetch = require("neogit.lib.git.fetch"),
   log = require("neogit.lib.git.log"),
+  refs = require("neogit.lib.git.refs"),
+  tag = require("neogit.lib.git.tag"),
   reflog = require("neogit.lib.git.reflog"),
   branch = require("neogit.lib.git.branch"),
   diff = require("neogit.lib.git.diff"),

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -123,6 +123,14 @@ local configurations = {
     },
   },
 
+  tag = config {
+    flags = {
+      n = "-n",
+      list = "--list",
+      delete = "--delete",
+    },
+  },
+
   rebase = config {
     flags = {
       interactive = "-i",
@@ -457,12 +465,21 @@ local configurations = {
   },
 
   ["ls-remote"] = config {
+    flags = {
+      tags = "--tags",
+    },
     aliases = {
       remote = function(tbl)
         return function(remote)
           return tbl.args(remote)
         end
       end,
+    },
+  },
+
+  ["for-each-ref"] = config {
+    options = {
+      format = "--format",
     },
   },
 

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -597,6 +597,7 @@ local mt_builder = {
         return tbl
       end
     end
+
     if action == "arg_list" then
       return function(args)
         for _, v in ipairs(args) do

--- a/lua/neogit/lib/git/refs.lua
+++ b/lua/neogit/lib/git/refs.lua
@@ -1,0 +1,15 @@
+local cli = require("neogit.lib.git.cli")
+
+local M = {}
+
+--- Lists revisions
+---@return table
+function M.list()
+  local revisions = cli["for-each-ref"].format('"%(refname:short)"').call():trim().stdout
+  for i, str in ipairs(revisions) do
+    revisions[i] = string.sub(str, 2, -2)
+  end
+  return revisions
+end
+
+return M

--- a/lua/neogit/lib/git/tag.lua
+++ b/lua/neogit/lib/git/tag.lua
@@ -1,0 +1,30 @@
+local cli = require("neogit.lib.git.cli")
+
+local M = {}
+
+--- Outputs a list of tags locally
+---@return table|nil List of tags.
+function M.list()
+  local revisions = cli.tag.list.call():trim().stdout
+  if #revisions == 0 then
+    return nil
+  end
+  return revisions
+end
+
+--- Deletes a list of tags
+---@param tags table List of tags
+---@return boolean Successfully deleted
+function M.delete(tags)
+  local result = cli.tag.delete.arg_list(unpack(tags)).call():trim()
+  return result.code == 0
+end
+
+--- Show a list of tags under a selected ref
+---@param remote string
+---@return table
+function M.list_remote(remote)
+  return cli["ls-remote"].tags.args(remote).call():trim().stdout
+end
+
+return M

--- a/lua/neogit/lib/git/tag.lua
+++ b/lua/neogit/lib/git/tag.lua
@@ -3,20 +3,16 @@ local cli = require("neogit.lib.git.cli")
 local M = {}
 
 --- Outputs a list of tags locally
----@return table|nil List of tags.
+---@return table List of tags.
 function M.list()
-  local revisions = cli.tag.list.call():trim().stdout
-  if #revisions == 0 then
-    return nil
-  end
-  return revisions
+  return cli.tag.list.call():trim().stdout
 end
 
 --- Deletes a list of tags
 ---@param tags table List of tags
 ---@return boolean Successfully deleted
 function M.delete(tags)
-  local result = cli.tag.delete.arg_list(unpack(tags)).call():trim()
+  local result = cli.tag.delete.arg_list(tags).call():trim()
   return result.code == 0
 end
 

--- a/lua/neogit/lib/input.lua
+++ b/lua/neogit/lib/input.lua
@@ -51,6 +51,10 @@ local function remove_completion_function(id)
   _G.__NEOGIT.completers[id] = nil
 end
 
+--- Provides the user with a confirmation
+---@param msg string Prompt to use for confirmation
+---@param options table|nil
+---@return boolean Confirmation (Yes/No)
 function M.get_confirmation(msg, options)
   options = options or {}
   options.values = options.values or { "&Yes", "&No" }
@@ -59,6 +63,14 @@ function M.get_confirmation(msg, options)
   return vim.fn.confirm(msg, table.concat(options.values, "\n"), options.default) == 1
 end
 
+---@class UserChoiceOptions
+---@field values table List of choices prefixed with '&'
+---@field default integer Default choice to select
+
+--- Provides the user with choices
+---@param msg string Prompt to use for the choices
+---@param options UserChoiceOptions
+---@return string First letter of the selected choice
 function M.get_choice(msg, options)
   local choice = vim.fn.confirm(msg, table.concat(options.values, "\n"), options.default)
   return options.values[choice]:match("&(.)")

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -389,6 +389,27 @@ local function format(template, values)
   end))
 end
 
+--- Compute the differences present in a and not in b
+---@param a table
+---@param b table
+---@return table
+local function set_difference(a, b)
+  local result = {}
+  for _, x in ipairs(a) do
+    local found = false
+    for _, y in ipairs(b) do
+      if x == y then
+        found = true
+        break
+      end
+    end
+    if not found then
+      table.insert(result, x)
+    end
+  end
+  return result
+end
+
 return {
   time = time,
   time_async = time_async,
@@ -425,4 +446,5 @@ return {
   str_wrap = str_wrap,
   debounce_trailing = debounce_trailing,
   format = format,
+  set_difference = set_difference,
 }

--- a/lua/neogit/popups/init.lua
+++ b/lua/neogit/popups/init.lua
@@ -77,6 +77,7 @@ function M.mappings_table()
         end),
       },
     },
+    { "TagPopup", "Tag", M.open("tag") },
     { "LogPopup", "Log", M.open("log") },
     {
       "CherryPickPopup",

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -93,18 +93,17 @@ function M.prune(_)
   local choices = { "&delete all", "&review each", "&abort" }
 
   if #l_tags > 0 then
-      local choice = input.get_choice(
-        #l_tags .. " tags can be removed locally",
-        { values = choices, default = #choices }
-      )
+    local choice =
+      input.get_choice(#l_tags .. " tags can be removed locally", { values = choices, default = #choices })
     if choice == "d" then
-      l_tags = {}
+      -- No-op
     elseif choice == "r" then
       l_tags = utils.filter(l_tags, function(tag)
+        vim.cmd.redraw()
         return input.get_confirmation("Delete local tag: " .. tag)
       end)
     else
-      return
+      l_tags = {}
     end
   end
 
@@ -115,13 +114,14 @@ function M.prune(_)
     )
 
     if choice == "d" then
-      r_tags = {}
+      -- no-op
     elseif choice == "r" then
       r_tags = utils.filter(r_tags, function(tag)
+        vim.cmd.redraw()
         return input.get_confirmation("Delete remote tag: " .. tag)
       end)
     else
-      return
+      r_tags = {}
     end
   end
 
@@ -136,8 +136,8 @@ function M.prune(_)
       table.insert(prune_tags, ":" .. tag)
     end
 
-    notification.info("Pruned remote tags: \n" .. table.concat(r_tags, "\n"))
     git.cli.push.arg_list({ selected_remote, unpack(prune_tags) }).call()
+    notification.info("Pruned remote tags: \n" .. table.concat(r_tags, "\n"))
   end
 end
 

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -57,7 +57,7 @@ end
 ---@param _ table
 function M.prune(_)
   local selected_remote = FuzzyFinderBuffer.new(git.remote.list()):open_async {
-    prompt_prefix = " Prune tags using remote > "
+    prompt_prefix = " Prune tags using remote > ",
   }
 
   if not selected_remote or selected_remote == "" then

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -44,7 +44,7 @@ function M.create_release(_) end
 ---@param _ table
 function M.delete(_)
   local tags = FuzzyFinderBuffer.new(git.tag.list()):open_async { allow_multi = true }
-  if #tags == 0 then
+  if #(tags or {}) == 0 then
     return
   end
 

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -66,9 +66,11 @@ function M.prune(_)
 
   local tags = git.tag.list()
   if #tags == 0 then
+    notification.info("No tags found")
     return
   end
 
+  notification.info("Fetching remote tags...")
   local r_out = git.tag.list_remote(selected_remote)
   local remote_tags = {}
 
@@ -82,6 +84,7 @@ function M.prune(_)
   local l_tags = utils.set_difference(tags, remote_tags)
   local r_tags = utils.set_difference(remote_tags, tags)
 
+  notification.delete_all()
   if #l_tags == 0 and #r_tags == 0 then
     notification.info("Same tags exist locally and remotely")
     return

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -1,0 +1,140 @@
+local M = {}
+local git = require("neogit.lib.git")
+local client = require("neogit.client")
+local utils = require("neogit.lib.util")
+local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
+local input = require("neogit.lib.input")
+local notification = require("neogit.lib.notification")
+local a = require("plenary.async")
+
+function M.create_tag(popup)
+  local tag_input = input.get_user_input("Tag name: ")
+  local options = git.refs.get_revisions()
+  local selected_branch = FuzzyFinderBuffer.new(options):open_async()
+  if not selected_branch then
+    return
+  end
+  local args = popup:get_arguments()
+  if vim.tbl_count(args) > 0 and not vim.tbl_contains(args, "--annotate") then
+    table.insert(args, "--annotate")
+  end
+
+  client.wrap(git.cli.tag.arg_list(utils.merge(args, { tag_input, selected_branch })), {
+    autocmd = "NeogitTagComplete",
+    msg = {
+      success = "Added tag " .. tag_input .. " on " .. selected_branch,
+      fail = "Failed to add tag " .. tag_input .. " on " .. selected_branch,
+    },
+  })
+end
+
+--- Create a release tag for `HEAD'.
+---@param _ table
+function M.create_release(_) end
+
+--- Delete one or more tags.
+--- If there are multiple tags then offer to delete those.
+--- Otherwise prompt for a single tag to be deleted.
+--- git tag -d TAGS
+---@param _ table
+function M.delete(_)
+  local options = git.tag.list()
+  local tags = {}
+  if options ~= nil then
+    local selected_tags = FuzzyFinderBuffer.new(options):open_async { allow_multi = true }
+    if #selected_tags == 0 then
+      return
+    end
+    tags = selected_tags
+  else
+    local tag_input = input.get_user_input("Tag name:")
+    if not tag_input or tag_input == "" then
+      return
+    end
+    table.insert(tags, tag_input)
+  end
+
+  local result = git.tag.delete(tags)
+  a.util.scheduler()
+  if result then
+    notification.info("Deleted tags: " .. table.concat(tags, ","))
+  end
+end
+
+--- Prunes differing tags from local and remote
+---@param _ table
+function M.prune(_)
+  local remotes = git.remote.list()
+  local selected_remote = FuzzyFinderBuffer.new(remotes)
+    :open_async { prompt_prefix = "Prune tags using remote" }
+  if not selected_remote or selected_remote == "" then
+    return
+  end
+  local tags = git.tag.list()
+  if tags == nil then
+    return
+  end
+  local r_out = git.tag.list_remote(selected_remote)
+  local remote_tags = {}
+  -- Tags that exist locally put
+  for _, line in ipairs(r_out) do
+    if not line:match("%^{}$") then
+      table.insert(remote_tags, line:sub(52))
+    end
+  end
+  local l_tags = utils.set_difference(tags, remote_tags)
+  local r_tags = utils.set_difference(remote_tags, tags)
+
+  if #l_tags == 0 and #r_tags == 0 then
+    a.util.scheduler()
+    notification.info("Same tags exist locally and remotely")
+    return
+  end
+
+  local choices = { "&delete all", "&review each", "&abort" }
+  if #l_tags > 0 then
+    local choice =
+      input.get_choice(#l_tags .. " tags can be removed locally", { values = choices, default = #choices })
+    if choice == "d" then
+      l_tags = {}
+    elseif choice == "r" then
+      l_tags = utils.filter(l_tags, function(tag)
+        return input.get_confirmation("Delete local tag: " .. tag)
+      end)
+    else
+      return
+    end
+  end
+  if #r_tags > 0 then
+    local choice = input.get_choice(
+      #r_tags .. " tags can be removed from remote",
+      { values = choices, default = #choices }
+    )
+    if choice == "d" then
+      r_tags = {}
+    elseif choice == "r" then
+      r_tags = utils.filter(r_tags, function(tag)
+        return input.get_confirmation("Delete remote tag: " .. tag)
+      end)
+    else
+      return
+    end
+  end
+
+  if #l_tags > 0 then
+    a.util.scheduler()
+    notification.info("Pruned local tags:\n" .. table.concat(l_tags, "\n"))
+    git.cli.tag.arg_list({ "-d", unpack(l_tags) }).call()
+  end
+  if #r_tags > 0 then
+    local prune_tags = {}
+    for _, tag in ipairs(r_tags) do
+      table.insert(prune_tags, ":" .. tag)
+    end
+    a.util.scheduler()
+    notification.info("Pruned remote tags: \n" .. table.concat(r_tags, "\n"))
+    git.cli.push.arg_list({ selected_remote, unpack(prune_tags) }).call()
+  end
+end
+
+return M

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -60,7 +60,7 @@ function M.prune(_)
     prompt_prefix = " Prune tags using remote > ",
   }
 
-  if not selected_remote or selected_remote == "" then
+  if (selected_remote or "") == "" then
     return
   end
 

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -95,6 +95,8 @@ function M.prune(_)
   if #l_tags > 0 then
     local choice =
       input.get_choice(#l_tags .. " tags can be removed locally", { values = choices, default = #choices })
+
+    -- selene: allow(empty_if)
     if choice == "d" then
       -- No-op
     elseif choice == "r" then
@@ -113,6 +115,7 @@ function M.prune(_)
       { values = choices, default = #choices }
     )
 
+    -- selene: allow(empty_if)
     if choice == "d" then
       -- no-op
     elseif choice == "r" then

--- a/lua/neogit/popups/tag/init.lua
+++ b/lua/neogit/popups/tag/init.lua
@@ -1,0 +1,27 @@
+local actions = require("neogit.popups.tag.actions")
+local popup = require("neogit.lib.popup")
+
+local M = {}
+
+function M.create()
+  local p = popup
+    .builder()
+    :name("NeogitTagPopup")
+    :arg_heading("Arguments")
+    :switch("f", "force", "Force")
+    :switch("a", "annotate", "Annotate")
+    :switch("s", "sign", "Sign")
+    :option("u", "local-user", "", "Sign as", { key_prefix = "-" })
+    :group_heading("Create")
+    :action("t", "tag", actions.create_tag)
+    :action("r", "release", nil)
+    :new_action_group("Do")
+    :action("x", "delete", actions.delete)
+    :action("p", "prune", actions.prune)
+    :build()
+  p:show()
+
+  return p
+end
+
+return M

--- a/lua/neogit/popups/tag/init.lua
+++ b/lua/neogit/popups/tag/init.lua
@@ -1,5 +1,5 @@
-local actions = require("neogit.popups.tag.actions")
 local popup = require("neogit.lib.popup")
+local actions = require("neogit.popups.tag.actions")
 
 local M = {}
 
@@ -14,11 +14,12 @@ function M.create()
     :option("u", "local-user", "", "Sign as", { key_prefix = "-" })
     :group_heading("Create")
     :action("t", "tag", actions.create_tag)
-    :action("r", "release", nil)
+    :action("r", "release")
     :new_action_group("Do")
     :action("x", "delete", actions.delete)
     :action("p", "prune", actions.prune)
     :build()
+
   p:show()
 
   return p


### PR DESCRIPTION
This commit implements the magit tag popup.

Completed:
- Create tag
- Delete tag

Needs improvement:
- Prune

Haven't started:
- Create release

The prune implementation works but I need to call `ls-remote` asynchronously as it takes  a bit of time.
I also need to figure out how to show the user the list of local/remote tags to be pruned by selecting the y option 🤔 .

Closes #783 