### PR TITLE
Prevent Telescope finder caching

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -142,6 +142,7 @@ local function default_opts()
     border = false,
     prompt_prefix = " > ",
     previewer = false,
+    cache_picker = false,
     layout_strategy = "bottom_pane",
     sorting_strategy = "ascending",
     theme = "ivy",


### PR DESCRIPTION
This is a very simple change to prevent Telescope from caching the finder.

Currently, if you open the finder in Neogit (when checking out a branch, for example), Telescope caches the picker state after it is closed. This overwrites any previously cached picker, which is inconvenient, but more importantly it means that if you then run `:Telescope resume`, it shows the old picker a second time, and attempting to close it results in a bunch of `cannot resume dead coroutine` errors.

I am not familiar with the codebase at all, but I had a feeling it would be a one-line fix so I thought I'd make a PR myself. This change fixes the issue for me, but if something needs to change somewhere else then feel free to add to or close this PR.