### PR TITLE
Only return default when the read value is _nil_.

### DIFF
--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -101,7 +101,12 @@ function M.get(key, default)
     return default
   end
 
-  return M.state[gen_key(key)] or default
+  local value = M.state[gen_key(key)]
+  if value ~= nil then
+    return value
+  else
+    return default
+  end
 end
 
 ---Reset current state, removing whats written to disk


### PR DESCRIPTION
If the value is false, and the default is true, then it'll always return the default instead.

Fixes #824 