### PR TITLE
docs: improve minimal init

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,39 +53,87 @@ body:
       description: "Minimal(!) configuration necessary to reproduce the issue. Save this as `minimal.lua`. If _absolutely_ necessary, add plugins and config options from your `init.lua` at the indicated lines."
       render: Lua
       value: |
-        vim.cmd([[set runtimepath=$VIMRUNTIME]])
-        vim.cmd([[set packpath=/tmp/nvim/site]])
-        local package_root = "/tmp/nvim/site/pack"
-        local install_path = package_root .. "/packer/start/packer.nvim"
-        local function load_plugins()
-          require("packer").startup({
-            {
-              "wbthomason/packer.nvim",
-              {
-                "NeogitOrg/neogit",
-                requires = {
-                  { "nvim-lua/plenary.nvim" },
-                  { "sindrets/diffview.nvim" },
-                },
-                config = function()
-                  print("loaded neogit")
-                  require("neogit").setup()
-                end,
-              },
-            },
-            config = {
-              package_root = package_root,
-              compile_path = install_path .. "/plugin/packer_compiled.lua",
-              display = { non_interactive = true },
-            },
+        -- NOTE: See the end of this file if you are reporting an issue, etc. Ignore all the "scary" functions up top, those are
+        -- used for setup and other operations.
+        local M = {}
+
+        local base_root_path = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h") .. "/.min"
+        function M.root(path)
+          return base_root_path .. "/" .. (path or "")
+        end
+
+        function M.load_plugin(plugin_name, plugin_url)
+          local package_root = M.root("plugins/")
+          local install_destination = package_root .. plugin_name
+          vim.opt.runtimepath:append(install_destination)
+
+          if not vim.loop.fs_stat(package_root) then
+            vim.fn.mkdir(package_root, "p")
+          end
+
+          if not vim.loop.fs_stat(install_destination) then
+            print(string.format("> Downloading plugin '%s' to '%s'", plugin_name, install_destination))
+            vim.fn.system({
+              "git",
+              "clone",
+              "--depth=1",
+              plugin_url,
+              install_destination,
+            })
+            if vim.v.shell_error > 0 then
+              error(string.format("> Failed to clone plugin: '%s' in '%s'!", plugin_name, install_destination),
+                vim.log.levels.ERROR)
+            end
+          end
+        end
+
+        ---@alias PluginName string The plugin name, will be used as part of the git clone destination
+        ---@alias PluginUrl string The git url at which a plugin is located, can be a path. See https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols for details
+        ---@alias MinPlugins table<PluginName, PluginUrl>
+
+        ---Do the initial setup. Downloads plugins, ensures the minimal init does not pollute the filesystem by keeping
+        ---everything self contained to the CWD of the minimal init file. Run prior to running tests, reproducing issues, etc.
+        ---@param plugins? table<PluginName, PluginUrl>
+        function M.setup(plugins)
+          vim.opt.packpath = {}                      -- Empty the package path so we use only the plugins specified
+          vim.opt.runtimepath:append(M.root(".min")) -- Ensure the runtime detects the root min dir
+
+          -- Install required plugins
+          if plugins ~= nil then
+            for plugin_name, plugin_url in pairs(plugins) do
+              M.load_plugin(plugin_name, plugin_url)
+            end
+          end
+
+          vim.env.XDG_CONFIG_HOME = M.root("xdg/config")
+          vim.env.XDG_DATA_HOME = M.root("xdg/data")
+          vim.env.XDG_STATE_HOME = M.root("xdg/state")
+          vim.env.XDG_CACHE_HOME = M.root("xdg/cache")
+
+          -- NOTE: Cleanup the xdg cache on exit so new runs of the minimal init doesn't share any previous state, e.g. shada
+          vim.api.nvim_create_autocmd("VimLeave", {
+            callback = function()
+              vim.fn.system({
+                "rm",
+                "-r",
+                "-f",
+                M.root("xdg")
+              })
+            end
           })
         end
-        if vim.fn.isdirectory(install_path) == 0 then
-          print("Installing neogit and dependencies.")
-          vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/wbthomason/packer.nvim", install_path })
-        end
-        load_plugins()
-        require("packer").sync()
+
+        -- NOTE: If you have additional plugins you need to install to reproduce your issue, include them in the plugins
+        -- table within the setup call below.
+        M.setup({
+          plenary = "https://github.com/nvim-lua/plenary.nvim.git",
+          telescope = "https://github.com/nvim-telescope/telescope.nvim",
+          diffview = "https://github.com/sindrets/diffview.nvim",
+          neogit = "https://github.com/NeogitOrg/neogit"
+        })
+        -- WARN: Do all plugin setup, test runs, reproductions, etc. AFTER calling setup with a list of plugins!
+        -- Basically, do all that stuff AFTER this line.
+        require("neogit").setup({}) -- For instance, setup Neogit
     validations:
       required: true
 


### PR DESCRIPTION
I guess I wasn't gone for long 😉.

### What does this PR do?

This PR significantly overhauls the minimal init in the `ISSUE_TEMPLATE/bug_report.yml` file. It's mostly a heavily
modified version of [@ten3roberts minimal init](https://github.com/NeogitOrg/neogit/pull/616/#discussion_r1264732449).

Per the requirements of #621, the new minimal init does the following:

- [x] Does not use a shared cache
- [x] Does not pollute global filesystem, instead uses a `.min` directory to save files in the current directory
- [x] Separates runs by cleaning up the `xdg` dir when vim exits
- [x] Does not use package managers to install plugins, instead we shell out to git
- [x] Persists dependencies between runs to speed up repeated invocations without modifying those dependencies
  - By default the minimal init downloads:
    - [Neogit](https://github.com/NeogitOrg/neogi)
    - [Telescope](https://github.com/nvim-telescope/telescope.nvim)
    - [Plenary](https://github.com/nvim-lua/plenary.nvim)
    - [Diffview](https://github.com/sindrets/diffview.nvim)

### Notes
- The minimal init does **_not_** setup any of the plugins. That's on the user to do as they may not be reporting a bug with telescope, diffview, etc.

- The new minimal init voids `packpath` and appends the path of each downloaded plugin to the `runtimepath`.

- One thing that we may want to change in this PR is that now the plugins are not saved into a temp directory and instead exist within the same directory as where the minimal init was ran from. If you want me to do a `mktemp` invocation and use a temp directory I can certainly make that happen.

### Fin.

If you like what you see in the minimal init I am thinking about copying some of it and shoving it into `tests/init.lua`
to better handle installing plugins and managing RTP.

Let me know what you think, I'm open to any changes or even an outright rejection of this PR if it is undesired 😃.

Closes #621
