### PR TITLE
fix: check if the timer is closing or closed before trying to close it

### DIFF
--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -168,9 +168,7 @@ function Process:start_timer()
         if not self.timer then
           return
         end
-        self.timer = nil
-        timer:stop()
-        timer:close()
+        self:stop_timer()
         if not self.result or (self.result.code ~= 0) then
           local message = string.format(
             "Command %q running for more than: %.1f seconds",
@@ -196,7 +194,9 @@ function Process:stop_timer()
     local timer = self.timer
     self.timer = nil
     timer:stop()
-    timer:close()
+    if not timer:is_closing() then
+      timer:close()
+    end
   end
 end
 


### PR DESCRIPTION
Simple fix to check if the handle is closing by using our process instance's `stop_timer` method instead of duplicating it in the `start_timer` method.

I'm curious as to the function `Process:start_timer`, why are we only starting a timer if the current instance's timer is `nil`? Is this so we don't accidentally mess with the current timer?

Fixes #843