### PR TITLE
Fix #305

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -102,7 +102,7 @@ function M.open(opts)
   else
     a.run(function()
       if status.status_buffer then
-        vim.cmd(string.format("cd %s", opts.cwd))
+        vim.cmd.lcd(opts.cwd)
         status.refresh(true)
       else
         status.create(opts.kind, opts.cwd)

--- a/lua/neogit/lib/git/init.lua
+++ b/lua/neogit/lib/git/init.lua
@@ -46,7 +46,7 @@ M.init_repo = function()
 
   local status = require("neogit.status")
   status.cwd_changed = true
-  vim.cmd(string.format("cd %s", directory))
+  vim.cmd.lcd(directory)
 
   M.create(directory)
 

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -637,7 +637,7 @@ local function close(skip_close)
   M.status_buffer = nil
   vim.o.autochdir = M.prev_autochdir
   if M.cwd_changed then
-    vim.cmd("cd -")
+    vim.cmd.lcd("-")
   end
 end
 
@@ -1416,7 +1416,7 @@ function M.create(kind, cwd)
 
       if cwd then
         M.cwd_changed = true
-        vim.cmd(string.format("cd %s", cwd))
+        vim.cmd.lcd(cwd)
       end
 
       vim.o.autochdir = false


### PR DESCRIPTION
Use vim.fn.lcd to only change the current directory for the current window window. Probably better.

Fixes #305