### PR TITLE
Feature: Allow user input to telescope prompt when no entries are available

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -30,8 +30,10 @@ local function telescope_mappings(on_select, allow_multi, refocus_status)
       for _, item in ipairs(picker:get_multi_selection()) do
         table.insert(selection, item[1])
       end
-    else
+    elseif action_state.get_selected_entry() ~= nil then
       table.insert(selection, action_state.get_selected_entry()[1])
+    else
+      table.insert(selection, picker:_get_prompt())
     end
 
     if not selection[1] or selection[1] == "" then


### PR DESCRIPTION
Allows for user to input an entry NOT available in telescope, and that just works fine.