### PR TITLE
format drive letter for per_project_settings

### DIFF
--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -16,12 +16,7 @@ function M.filepath()
   local filename = "state"
 
   if config.values.use_per_project_settings then
-    filename = vim.loop.cwd():gsub("/", "%%")
-  end
-
-  if vim.loop.os_uname().sysname == "Windows_NT" then
-    base_path = base_path:gsub("/", "\\")
-    filename = filename:gsub("\\", "%%")
+    filename = vim.loop.cwd():gsub("^%a:", ""):gsub("/", "%%")
   end
 
   return Path:new(base_path .. filename)

--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -16,7 +16,10 @@ function M.filepath()
   local filename = "state"
 
   if config.values.use_per_project_settings then
-    filename = vim.loop.cwd():gsub("^%a:", ""):gsub("/", "%%")
+    filename = vim.loop.cwd()
+      :gsub("^(%a):", "/%1")
+      :gsub("/", "%%")
+      :gsub(Path.sep, "%%")
   end
 
   return Path:new(base_path .. filename)

--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -16,10 +16,7 @@ function M.filepath()
   local filename = "state"
 
   if config.values.use_per_project_settings then
-    filename = vim.loop.cwd()
-      :gsub("^(%a):", "/%1")
-      :gsub("/", "%%")
-      :gsub(Path.path.sep, "%%")
+    filename = vim.loop.cwd():gsub("^(%a):", "/%1"):gsub("/", "%%"):gsub(Path.path.sep, "%%")
   end
 
   return Path:new(base_path .. filename)

--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -19,7 +19,7 @@ function M.filepath()
     filename = vim.loop.cwd()
       :gsub("^(%a):", "/%1")
       :gsub("/", "%%")
-      :gsub(Path.sep, "%%")
+      :gsub(Path.path.sep, "%%")
   end
 
   return Path:new(base_path .. filename)


### PR DESCRIPTION
Absolute paths in windows always start with a drive letter which has to be stripped or formatted. As far as I can tell from my testing this makes detecting the platform unnecessary, as the base path and filename don't need further modification, and stripping a drive letter that isn't there is harmless.

This resolves issue https://github.com/NeogitOrg/neogit/issues/469