### PR TITLE
Fix: Properly return table when multiselect is enabled.

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -224,12 +224,9 @@ function Finder:find(on_select)
         return entry
       end,
     }, function(item)
-      if type(item) ~= "table" then
-        item = { item }
-      end
-
       vim.schedule(function()
-        on_select(item)
+        on_select(self.opts.allow_multi and { item } or item)
+
         if self.opts.refocus_status then
           refocus_status_buffer()
         end


### PR DESCRIPTION
Fixes #872 and #863 

Can't blindly cast to table. Only return a table if multi-select was requested (consistent with fzf/telescope)