### PR TITLE
feat: interactive rebase should include current commit

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -483,6 +483,15 @@ local configurations = {
     },
   },
 
+  ["rev-list"] = config {
+    flags = {
+      parents = "--parents",
+    },
+    options = {
+      max_count = "--max-count",
+    },
+  },
+
   ["rev-parse"] = config {
     flags = {
       verify = "--verify",

--- a/lua/neogit/popups/rebase/actions.lua
+++ b/lua/neogit/popups/rebase/actions.lua
@@ -69,7 +69,15 @@ function M.interactively(popup)
   end
 
   if commit then
-    git.rebase.rebase_interactive(commit, popup:get_arguments())
+    local args = popup:get_arguments()
+    local parent_commit = git.cli["rev-list"].max_count(1).parents.args(commit).call().stdout[1]
+    if commit ~= parent_commit then
+      commit = vim.split(parent_commit, " ")[2]
+    else
+      table.insert(args, "--root")
+    end
+
+    git.rebase.rebase_interactive(commit, args)
   end
 end
 


### PR DESCRIPTION
As discussed in https://github.com/NeogitOrg/neogit/discussions/862

I really tried to write a test for this, but couldn't figure out how to wait until the `git-rebase-todo` was present to check its contents. Maybe later :)

Feedback very welcomed, as always.