### PR TITLE
Fix: When in a new repo, don't error out

### DIFF
--- a/lua/neogit/lib/git/rev_parse.lua
+++ b/lua/neogit/lib/git/rev_parse.lua
@@ -7,8 +7,12 @@ local cli = require("neogit.lib.git.cli")
 ---@async
 function M.abbreviate_commit(oid)
   assert(oid, "Missing oid")
-  local abbrev = cli["rev-parse"].short.args(oid).call().stdout[1]
-  return abbrev
+
+  if oid == "(initial)" then
+    return "(initial)"
+  else
+    return cli["rev-parse"].short.args(oid).call().stdout[1]
+  end
 end
 
 return M


### PR DESCRIPTION
Fixes #879 