### PR TITLE
test: fix random test fail in status spec

### DIFF
--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -879,6 +879,8 @@ local stage = function()
 end
 
 local unstage = function()
+  M.current_operation = "unstage"
+
   local selection = M.get_selection()
   local mode = vim.api.nvim_get_mode()
 


### PR DESCRIPTION
After reviewing the test and the code in [lua/neogit/status.lua](https://github.com/NeogitOrg/neogit/blob/master/lua/neogit/status.lua) I noticed that stage and discard set `M.current_operation` but unstage does not.

The assertion for unstaging that occasionally fails comes right after an `act()` line, and the last line in `act()` is `status.wait_on_current_operation()`, which checks if `status.current_operation` is set.

## Local testing results

I tested locally with just the four unstage tests (the other tests in the status spec were commented), and without this change I ran the test in a loop three times and it failed at runs 122, 119, and 74. With the fix in place, I was not able to reproduce a failure. I ran the test in a loop two times and stopped the loop at runs 1130 and 1360, satisfied that the random failure has been squashed.

Fixes: #887