### PR TITLE
fix: do not crash when opening commit if no email or no user

### DIFF
--- a/lua/neogit/buffers/commit_view/ui.lua
+++ b/lua/neogit/buffers/commit_view/ui.lua
@@ -35,12 +35,12 @@ function M.CommitHeader(info)
     commit_header_arg(info),
     row {
       text.highlight("Comment")("Author:     "),
-      text(info.author_name .. " <" .. info.author_email .. ">"),
+      text((info.author_name or "") .. " <" .. (info.author_email or "") .. ">"),
     },
     row { text.highlight("Comment")("AuthorDate: "), text(info.author_date) },
     row {
       text.highlight("Comment")("Committer:  "),
-      text(info.committer_name .. " <" .. info.committer_email .. ">"),
+      text((info.committer_name or "") .. " <" .. (info.committer_email or "") .. ">"),
     },
     row { text.highlight("Comment")("CommitDate: "), text(info.committer_date) },
   }


### PR DESCRIPTION
this pr fixes a crash when opening a commit if some info about the commit are `nil`

```
Parsing commit...                                                                                                                                                                                   
Error executing vim.schedule lua callback: ...ck/packer/start/plenary.nvim/lua/plenary/async/async.lua:18: The coroutine failed with this message: ...acker/start/neogit/lua/neogit/buffers/commit_v
iew/ui.lua:38: attempt to concatenate field 'author_email' (a nil value)                                                                                                                            
stack traceback:                                                                                                                                                                                    
        [C]: in function 'error'                                                                                                                                                                    
        ...ck/packer/start/plenary.nvim/lua/plenary/async/async.lua:18: in function 'callback_or_next'                                                                                              
        ...ck/packer/start/plenary.nvim/lua/plenary/async/async.lua:45: in function <...ck/packer/start/plenary.nvim/lua/plenary/async/async.lua:44>                                                
```                                                                                                         