### PR TITLE
feat: Prefill branch rename prompt with the selected branch name

### DIFF
--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -155,7 +155,7 @@ M.rename_branch = operation("rename_branch", function()
     return
   end
 
-  local new_name = input.get_user_input("new branch name > ")
+  local new_name = input.get_user_input("new branch name > ", selected_branch)
   if not new_name or new_name == "" then
     return
   end


### PR DESCRIPTION
I feel like the most common use case for branch renames is fixing typos. For me (and likely others) DX would be greatly improved if the prompt would come already prefilled with the name of the branch which is being renamed.

To our luck `input.get_user_input` already supports default value as its second parameter, DRY code achieved!