### PR TITLE
Feat: Add "use_default_keymaps" boolean to user config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ neogit.setup {
     "NeogitCommitPopup--allow-empty",
     "NeogitRevertPopup--no-edit",
   },
+  -- Set to false if you want to be responsible for creating _ALL_ keymappings
+  use_default_keymaps = true,
   -- Neogit refreshes its internal state after specific events, which can be expensive depending on the repository size.
   -- Disabling `auto_refresh` will make it so you have to manually refresh the status after you open it.
   auto_refresh = true,

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -701,6 +701,16 @@ function M.setup(opts)
   if opts ~= nil then
     if opts.use_default_keymaps == false then
       M.values.mappings = { status = {}, popup = {}, finder = {} }
+    else
+      -- Clear our any "false" user mappings from defaults
+      for section, maps in pairs(opts.mappings or {}) do
+        for k, v in pairs(maps) do
+          if v == false then
+            M.values.mappings[section][k] = nil
+            opts.mappings[section][k] = nil
+          end
+        end
+      end
     end
 
     M.values = vim.tbl_deep_extend("force", M.values, opts)

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -129,11 +129,13 @@ end
 ---@field ignored_settings? string[] Settings to never persist, format: "Filetype--cli-value", i.e. "NeogitCommitPopup--author"
 ---@field mappings? NeogitConfigMappings
 ---@field notification_icon? String
+---@field use_default_keymaps? Boolean
 
 ---Returns the default Neogit configuration
 ---@return NeogitConfig
 function M.get_default_values()
   return {
+    use_default_keymaps = true,
     disable_hint = false,
     disable_context_highlighting = false,
     disable_signs = false,
@@ -697,6 +699,10 @@ end
 
 function M.setup(opts)
   if opts ~= nil then
+    if opts.use_default_keymaps == false then
+      M.values.mappings = { status = {}, popup = {}, finder = {} }
+    end
+
     M.values = vim.tbl_deep_extend("force", M.values, opts)
   end
 


### PR DESCRIPTION
 Setting to "false" will leave _all_ mappings up to user.