### PR TITLE
Breaking: Change Commit/Merge/Rebase/Tag editor default from "split" to "auto"

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -168,7 +168,7 @@ function M.get_default_values()
       recent_commit_count = 10,
     },
     commit_editor = {
-      kind = "split",
+      kind = "auto",
     },
     commit_select_view = {
       kind = "tab",
@@ -181,16 +181,16 @@ function M.get_default_values()
       kind = "tab",
     },
     rebase_editor = {
-      kind = "split",
+      kind = "auto",
     },
     reflog_view = {
       kind = "tab",
     },
     merge_editor = {
-      kind = "split",
+      kind = "auto",
     },
     tag_editor = {
-      kind = "split",
+      kind = "auto",
     },
     preview_buffer = {
       kind = "split",


### PR DESCRIPTION
This means that if the current window is `> 80 * 2` cells wide, the editor is opened as a vsplit, otherwise it's opened as a split.

To restore the previous behaviour, just set the values to "split"