### PR TITLE
Update neogit kind defaults in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ neogit.setup {
     recent_commit_count = 10,
   },
   commit_editor = {
-    kind = "split",
+    kind = "auto",
   },
   commit_select_view = {
     kind = "tab",
@@ -129,16 +129,16 @@ neogit.setup {
     kind = "tab",
   },
   rebase_editor = {
-    kind = "split",
+    kind = "auto",
   },
   reflog_view = {
     kind = "tab",
   },
   merge_editor = {
-    kind = "split",
+    kind = "auto",
   },
   tag_editor = {
-    kind = "split",
+    kind = "auto",
   },
   preview_buffer = {
     kind = "split",


### PR DESCRIPTION
Latest commit at time of creating pr (being https://github.com/NeogitOrg/neogit/commit/096249f6c7fa4af5cc6e0d41c4ff2fffb351e273) changes kind for popups, but is not documented in the README, thought I'd just fix that myself