### PR TITLE
refactor: set Neogit `cwd` to git root if `cwd` unspecified

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -67,7 +67,7 @@ function M.open(opts)
   end
 
   if not opts.cwd then
-    opts.cwd = vim.fn.getcwd()
+    opts.cwd = require("neogit.lib.git.cli").git_root()
   end
 
   if not did_setup then


### PR DESCRIPTION
This sets the Neogit `cwd` to the git root if left unspecified. This makes Neogit more in line with Magit in its presentation of files.


Some sceenshots below.
As a note, my git root is `~/dots` for the repo I am demonstrating this in and I am opening Neovim in my `dots/.config/neovim/lua` directory.

Before:
![image](https://github.com/NeogitOrg/neogit/assets/58627896/6023def3-7eb3-4f4d-80e6-33ae9e40b34d)


After:
![image](https://github.com/NeogitOrg/neogit/assets/58627896/16c21700-0530-41fd-98b4-a8181e16a5b6)


Closes #906