### PR TITLE
Graph colors

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -265,6 +265,7 @@ NeogitFilePath              Applied to filepath
 NeogitCommitViewHeader      Applied to header of Commit View
 
 LOG VIEW BUFFER
+NeogitGraphAuthor           Applied to the commit's author in graph view
 NeogitGraphBlack            Used when --colors is enabled for graph
 NeogitGraphBlackBold
 NeogitGraphRed

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -152,7 +152,7 @@ M.CommitEntry = Component.new(function(commit, args)
     details = col.hidden(true).padding_left(8) {
       row(util.merge(graph, {
         text(" "),
-        text("Author:     ", { highlight = "Comment" }),
+        text("Author:     ", { highlight = "NeogitGraphAuthor" }),
         text(commit.author_name),
         text(" <"),
         text(commit.author_email),
@@ -209,7 +209,7 @@ M.CommitEntry = Component.new(function(commit, args)
           { " ", "Constant" },
           {
             util.str_clamp(commit.author_name, 30 - (#commit.rel_date > 10 and #commit.rel_date or 10)),
-            "Constant",
+            "NeogitGraphAuthor",
           },
           { util.str_min_width(commit.rel_date, 10), "Special" },
         },

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -122,17 +122,23 @@ M.CommitEntry = Component.new(function(commit, args)
 
     if local_name and remote_name and vim.endswith(remote_name, local_name) then
       local remote = remote_name:match("^([^/]*)/.*$")
-      table.insert(ref, text(remote .. "/", { highlight = "String" }))
-      table.insert(ref, text(local_name, { highlight = "Macro" }))
+      table.insert(ref, text(remote .. "/", { highlight = "NeogitRemote" }))
+      table.insert(ref, text(local_name, { highlight = "NeogitBranch" }))
       table.insert(ref, text(" "))
     else
       if local_name then
-        table.insert(ref, text(local_name, { highlight = local_name:match("/") and "String" or "Macro" }))
+        table.insert(
+          ref,
+          text(local_name, { highlight = local_name:match("/") and "NeogitRemote" or "NeogitBranch" })
+        )
         table.insert(ref, text(" "))
       end
 
       if remote_name then
-        table.insert(ref, text(remote_name, { highlight = remote_name:match("/") and "String" or "Macro" }))
+        table.insert(
+          ref,
+          text(remote_name, { highlight = remote_name:match("/") and "NeogitRemote" or "NeogitBranch" })
+        )
         table.insert(ref, text(" "))
       end
     end

--- a/lua/neogit/lib/hl.lua
+++ b/lua/neogit/lib/hl.lua
@@ -107,6 +107,7 @@ function M.setup()
 
   -- stylua: ignore start
   hl_store = {
+    NeogitGraphAuthor = { fg = palette.orange },
     NeogitGraphRed = { fg = palette.red },
     NeogitGraphWhite = { fg = palette.white },
     NeogitGraphYellow = { fg = palette.yellow },


### PR DESCRIPTION
Hi there,

first of all, thanks again for this amazing package! Long time emacs user decided to switch to nvim just because of you ^^

I was trying to configure the look and feel of the log graph view of `neogit` to match more the original color scheme of magit:

![magit-graph](https://github.com/NeogitOrg/neogit/assets/31999281/5042892e-92c9-43f0-bdbb-50bee74d6a01)

However with my config the colors of neogit look rather dull:

![neogit-graph](https://github.com/NeogitOrg/neogit/assets/31999281/5eaf86e6-f13e-4ade-97db-b4c510fc4423)

I tried to configure the `NeogitGraph*` highlight groups without success. After digging a bit through the code of neogit, I noticed that you use `Macro` and `String` highlight groups for local/remote branch names. Maybe these could reuse the [NeogitBranch & NeogitRemote](https://github.com/NeogitOrg/neogit/blob/master/doc/neogit.txt#L201-L202) highlight groups instead?

I don't have much experience with Lua or highlight groups, so please let me know if there is another (better?) way to configure this =)