### PR TITLE
Use opt_local to set window local variables

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -491,19 +491,13 @@ function Buffer.create(config)
   end
 
   buffer:call(function()
-    -- This sets fold styling for Neogit windows without overriding user styling
-    local hl = vim.wo.winhl
-    if hl ~= "" then
-      hl = hl .. ","
-    end
-    vim.wo.winhl = hl .. "Folded:NeogitFold"
+    -- Set fold styling for Neogit windows while preserving user styling
+    vim.opt_local.winhl:append("Folded:NeogitFold")
 
-    -- If signs are not disabled, avoid overrided by user settings
-    buffer:call(function()
-      if not config.disable_signs then
-        vim.wo.signcolumn = "auto"
-      end
-    end)
+    -- Set signcolumn unless disabled by user settings
+    if not config.disable_signs then
+      vim.opt_local.signcolumn = "auto"
+    end
   end)
 
   if config.context_highlight then


### PR DESCRIPTION
See the documentation for `vim.wo` -- the previous implementation set a global value instead of local:
```
vim.wo[{winid}]                                                                *vim.wo*
    Get or set window-scoped |options| for the window with handle {winid}.
    Like `:set`. If [{winid}] is omitted then the current window is used.
    Invalid {winid} or key is an error.

    Note: this does not access |local-options| (`:setlocal`) instead use: >lua
        nvim_get_option_value(OPTION, { scope = 'local', win = winid })
        nvim_set_option_value(OPTION, VALUE, { scope = 'local', win = winid }
<
    Example: >lua
        local winid = vim.api.nvim_get_current_win()
        vim.wo[winid].number = true    -- same as vim.wo.number = true
        print(vim.wo.foldmarker)
        print(vim.wo.quux)             -- error: invalid key
```

Fixes: https://github.com/NeogitOrg/neogit/issues/936