### PR TITLE
Update git_root on refresh

### DIFF
--- a/lua/neogit/lib/git/repository.lua
+++ b/lua/neogit/lib/git/repository.lua
@@ -3,7 +3,7 @@ local logger = require("neogit.logger")
 
 -- git-status outputs files relative to the cwd.
 --
--- Save the working directory to allow resolution to absolute paths since the
+-- Save the git_root to allow resolution to absolute paths since the
 -- cwd may change after the status is refreshed and used, especially if using
 -- rooter plugins with lsp integration
 -- stylua: ignore start
@@ -15,7 +15,6 @@ local function empty_state()
     git_path     = function(...)
       return Path.new(root):joinpath(".git", ...)
     end,
-    cwd          = vim.fn.getcwd(),
     git_root     = root,
     head         = {
       branch = nil,

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -171,9 +171,8 @@ local function update_status(state)
   state.git_root = git_root
   local Path = require("plenary.path")
   state.git_path = function(...)
-      return Path.new(git_root):joinpath(".git", ...)
+    return Path.new(git_root):joinpath(".git", ...)
   end
-
 end
 
 local function update_branch_information(state)

--- a/tests/util/git_harness.lua
+++ b/tests/util/git_harness.lua
@@ -53,10 +53,11 @@ end
 
 function M.in_prepared_repo(cb)
   return function()
-    local dir = M.prepare_repository()
     require("neogit").setup()
-    vim.cmd("Neogit")
     a.util.block_on(status.reset)
+    local dir = M.prepare_repository()
+    vim.cmd("Neogit")
+    a.util.block_on(status.refresh)
     a.util.block_on(function()
       local _, err = pcall(cb, dir)
       if err ~= nil then


### PR DESCRIPTION
Fixes https://github.com/NeogitOrg/neogit/issues/931 and fixes https://github.com/NeogitOrg/neogit/issues/442

This PR updates `in_prepared_repo` to a different scenario (called "Scenario 2"), namely that the user changes directory to a git repo after `setup()` has already been called. This makes 14 tests fail, also including the tests for hunk operations which explains the issue https://github.com/NeogitOrg/neogit/issues/931.

The second commit fixes all failing tests, by making sure `repository.git_root` and `repository.git_path` is updated on every refresh of the status. Also this commit removes the unused `repository.cwd`.

Maybe this PR could be extended so that `in_prepared_repo` would run each test for both scenarios:
1) Scenario 1: User runs setup() while already being in the right git repo (i.e. you start `nvim` inside the git repo).
2) Scenario 2: User changes directory after setup() has been called (i.e. you start `nvim` and then `:cd` into the git repo)

I was not able to fit both scenarios into `in_prepared_repo` because running Scenario 1 first would influence the outcome of running Scenario 2, so some critical cleanup was missing between running both scenarios. Maybe somebody can help me with this? With the bugfix included in this PR all tests pass when running them in either Scenario 1 and Scenario 2 separately. We could of course also duplicate all tests, but that would be ugly. What we really want is that that every test passes in either scenario, because that assert that neogit behaves the same.
