### PR TITLE
Update Makefile: Set LUA_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	TEST_FILES=$$TEST_FILES NEOGIT_LOG_LEVEL=error NEOGIT_LOG_CONSOLE="sync" GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null NVIM_APPNAME=neogit-test nvim --headless -S "./tests/init.lua"
+	LUA_PATH="./?.lua" TEST_FILES=$$TEST_FILES NEOGIT_LOG_LEVEL=error NEOGIT_LOG_CONSOLE="sync" GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null NVIM_APPNAME=neogit-test nvim --headless -S "./tests/init.lua"
 
 lint:
 	selene --config selene/config.toml lua


### PR DESCRIPTION
Without the changes in this PR `make test` fails on my machine like this

```
$ make test
TEST_FILES=$TEST_FILES NEOGIT_LOG_LEVEL=error NEOGIT_LOG_CONSOLE="sync" GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null NVIM_APPNAME=neogit-test nvim --headless -S "./tests/init.lua"
Error detected while processing command line..script /home/stefan/repos/neogit/tests/init.lua:
E5113: Error while calling lua chunk: /home/stefan/repos/neogit/tests/init.lua:1: module 'tests.util.util' not found:
...
```