### PR TITLE
Show HEAD as `NeogitPopupBranchName` in Log Graph

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -199,9 +199,9 @@ these yourself before the plugin loads, that will be respected. If they do not
 exist, they will be created with sensible defaults based on your colorscheme.
 
 STATUS BUFFER
-NeogitBranch                Header showing currently checked out branch
-NeogitBranchHead            Currently checkoued branch (in log graph)
-NeogitRemote                Header showing current branch's remote (if set)
+NeogitBranch                Local branches
+NeogitBranchHead            Accent highlight for current HEAD in LogBuffer
+NeogitRemote                Remote branches
 NeogitObjectId              Object's SHA hash
 NeogitStash                 Stash name
 NeogitFold                  Folded text highlight

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -200,6 +200,7 @@ exist, they will be created with sensible defaults based on your colorscheme.
 
 STATUS BUFFER
 NeogitBranch                Header showing currently checked out branch
+NeogitBranchHead            Currently checkoued branch (in log graph)
 NeogitRemote                Header showing current branch's remote (if set)
 NeogitObjectId              Object's SHA hash
 NeogitStash                 Stash name

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -120,16 +120,19 @@ M.CommitEntry = Component.new(function(commit, args)
       remote_name, local_name = local_name, remote_name
     end
 
+    local is_head = string.match(commit.ref_name, "HEAD") ~= nil
+    local branch_highlight = is_head and "NeogitBranchHead" or "NeogitBranch"
+
     if local_name and remote_name and vim.endswith(remote_name, local_name) then
       local remote = remote_name:match("^([^/]*)/.*$")
       table.insert(ref, text(remote .. "/", { highlight = "NeogitRemote" }))
-      table.insert(ref, text(local_name, { highlight = "NeogitBranch" }))
+      table.insert(ref, text(local_name, { highlight = branch_highlight }))
       table.insert(ref, text(" "))
     else
       if local_name then
         table.insert(
           ref,
-          text(local_name, { highlight = local_name:match("/") and "NeogitRemote" or "NeogitBranch" })
+          text(local_name, { highlight = local_name:match("/") and "NeogitRemote" or branch_highlight })
         )
         table.insert(ref, text(" "))
       end
@@ -137,7 +140,7 @@ M.CommitEntry = Component.new(function(commit, args)
       if remote_name then
         table.insert(
           ref,
-          text(remote_name, { highlight = remote_name:match("/") and "NeogitRemote" or "NeogitBranch" })
+          text(remote_name, { highlight = remote_name:match("/") and "NeogitRemote" or branch_highlight })
         )
         table.insert(ref, text(" "))
       end

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -120,7 +120,7 @@ M.CommitEntry = Component.new(function(commit, args)
       remote_name, local_name = local_name, remote_name
     end
 
-    local is_head = string.match(commit.ref_name, "HEAD") ~= nil
+    local is_head = string.match(commit.ref_name, "HEAD %->") ~= nil
     local branch_highlight = is_head and "NeogitBranchHead" or "NeogitBranch"
 
     if local_name and remote_name and vim.endswith(remote_name, local_name) then

--- a/lua/neogit/lib/hl.lua
+++ b/lua/neogit/lib/hl.lua
@@ -164,6 +164,7 @@ function M.setup()
     NeogitCommandCodeNormal = { link = "String" },
     NeogitCommandCodeError = { link = "Error" },
     NeogitBranch = { fg = palette.blue, bold = true },
+    NeogitBranchHead = { fg = palette.blue, bold = true, underline = true },
     NeogitRemote = { fg = palette.green, bold = true },
     NeogitUnmergedInto = { fg = palette.bg_purple, bold = true },
     NeogitUnpushedTo = { fg = palette.bg_purple, bold = true },


### PR DESCRIPTION
Follow-up after #934: In the log graph it's a bit non-intuitive where the currently checked out branch is. To make this more customizable for the user, we could reuse the `NeogitPopupBranchName` highlight group.