### PR TITLE
use plenary.path to handle joining the state path

### DIFF
--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -12,14 +12,14 @@ end
 
 ---@return Path
 function M.filepath()
-  local base_path = Path.joinpath(vim.fn.stdpath("state"), "neogit")
+  local state_path = Path.new(vim.fn.stdpath("state")):joinpath("neogit")
   local filename = "state"
 
   if config.values.use_per_project_settings then
     filename = vim.loop.cwd():gsub("^(%a):", "/%1"):gsub("/", "%%"):gsub(Path.path.sep, "%%")
   end
 
-  return Path:joinpath(base_path, filename)
+  return state_path:joinpath(filename)
 end
 
 ---Initializes state

--- a/lua/neogit/lib/state.lua
+++ b/lua/neogit/lib/state.lua
@@ -12,14 +12,14 @@ end
 
 ---@return Path
 function M.filepath()
-  local base_path = vim.fn.stdpath("state") .. "/neogit/"
+  local base_path = Path.joinpath(vim.fn.stdpath("state"), "neogit")
   local filename = "state"
 
   if config.values.use_per_project_settings then
     filename = vim.loop.cwd():gsub("^(%a):", "/%1"):gsub("/", "%%"):gsub(Path.path.sep, "%%")
   end
 
-  return Path:new(base_path .. filename)
+  return Path:joinpath(base_path, filename)
 end
 
 ---Initializes state


### PR DESCRIPTION
fixes remaining issue on https://github.com/NeogitOrg/neogit/issues/469 where errors were occurring when the state folder didn't already exist on windows.