### PR TITLE
Correct tag highlight in Log Graph

### DIFF
--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -118,7 +118,7 @@ M.CommitEntry = Component.new(function(commit, args)
     local is_head = string.match(commit.ref_name, "HEAD %->") ~= nil
     local branch_highlight = is_head and "NeogitBranchHead" or "NeogitBranch"
 
-    local items = log.interprete(ref_name, remote.list())
+    local items = log.branch_info(ref_name, remote.list())
     for branch, remotes in pairs(items.branches) do
       if #remotes == 1 then
         table.insert(ref, text(remotes[1] .. "/", { highlight = "NeogitRemote" }))

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -1,8 +1,7 @@
 local Ui = require("neogit.lib.ui")
 local Component = require("neogit.lib.ui.component")
 local util = require("neogit.lib.util")
-local log = require("neogit.lib.git.log")
-local remote = require("neogit.lib.git.remote")
+local git = require("neogit.lib.git")
 
 local text = Ui.text
 local col = Ui.col
@@ -118,7 +117,7 @@ M.CommitEntry = Component.new(function(commit, args)
     local is_head = string.match(commit.ref_name, "HEAD %->") ~= nil
     local branch_highlight = is_head and "NeogitBranchHead" or "NeogitBranch"
 
-    local items = log.branch_info(ref_name, remote.list())
+    local items = git.log.branch_info(ref_name, git.remote.list())
     for branch, remotes in pairs(items.branches) do
       if #remotes == 1 then
         table.insert(ref, text(remotes[1] .. "/", { highlight = "NeogitRemote" }))

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -113,11 +113,21 @@ M.CommitEntry = Component.new(function(commit, args)
   -- Parse out ref names
   if args.decorate and commit.ref_name ~= "" then
     local ref_name, _ = commit.ref_name:gsub("HEAD %-> ", "")
-    local remote_name, local_name = unpack(vim.split(ref_name, ", "))
 
-    -- Sometimes the log output will list remote/local names in reverse order
-    if (local_name and local_name:match("/")) and (remote_name and not remote_name:match("/")) then
-      remote_name, local_name = local_name, remote_name
+    local names = vim.split(ref_name, ", ")
+    local local_name = nil
+    local remote_name = nil
+    local tag_name = nil
+    for _, name in ipairs(names) do
+      if name:match("^tag: .*") ~= nil then
+        tag_name = name:gsub("tag: ", "")
+      end
+      if local_name == nil and not name:match("/") then
+        local_name = name
+      end
+      if remote_name == nil and name:match("/") then
+        remote_name = name
+      end
     end
 
     local is_head = string.match(commit.ref_name, "HEAD %->") ~= nil
@@ -144,6 +154,11 @@ M.CommitEntry = Component.new(function(commit, args)
         )
         table.insert(ref, text(" "))
       end
+    end
+
+    if tag_name ~= nil then
+      table.insert(ref, text(tag_name, { highlight = "NeogitTagName" }))
+      table.insert(ref, text(" "))
     end
   end
 

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -117,8 +117,12 @@ M.CommitEntry = Component.new(function(commit, args)
     local is_head = string.match(commit.ref_name, "HEAD %->") ~= nil
     local branch_highlight = is_head and "NeogitBranchHead" or "NeogitBranch"
 
-    local items = git.log.branch_info(ref_name, git.remote.list())
-    for branch, remotes in pairs(items.branches) do
+    local info = git.log.branch_info(ref_name, git.remote.list())
+    for _, branch in ipairs(info.untracked) do
+      table.insert(ref, text(branch, { highlight = "NeogitBranch" }))
+      table.insert(ref, text(" "))
+    end
+    for branch, remotes in pairs(info.tracked) do
       if #remotes == 1 then
         table.insert(ref, text(remotes[1] .. "/", { highlight = "NeogitRemote" }))
       end
@@ -128,7 +132,7 @@ M.CommitEntry = Component.new(function(commit, args)
       table.insert(ref, text(branch, { highlight = branch_highlight }))
       table.insert(ref, text(" "))
     end
-    for _, tag in pairs(items.tags) do
+    for _, tag in pairs(info.tags) do
       table.insert(ref, text(tag, { highlight = "NeogitTagName" }))
       table.insert(ref, text(" "))
     end

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -447,7 +447,7 @@ end
 ---   * "origin/main, main, origin/HEAD, tag: 1.2.3, fork/develop"
 --- @param remotes string[] list of remote names, e.g. by calling `require("neogit.lib.git.remote").list()`
 --- @return CommitBranchInfo
-function M.interprete(ref, remotes)
+function M.branch_info(ref, remotes)
   local parts = vim.split(ref, ", ")
   local result = {
     branches = {},

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -454,30 +454,33 @@ function M.interprete(ref, remotes)
     tags = {},
   }
   for _, part in ipairs(parts) do
+    local skip = false
     if part:match("^tag: .*") ~= nil then
       local tag = part:gsub("tag: ", "")
       table.insert(result.tags, tag)
       -- No need to annotate tags with remotes, probably too cluttered
-      goto continue
+      skip = true
     end
     local has_remote = false
     for _, remote in ipairs(remotes) do
-      if part:match("^" .. remote .. "/") then
-        has_remote = true
-        local name = part:gsub("^" .. remote .. "/", "")
-        if name == "HEAD" then
-          goto continue
+      if not skip then
+        if part:match("^" .. remote .. "/") then
+          has_remote = true
+          local name = part:gsub("^" .. remote .. "/", "")
+          if name == "HEAD" then
+            skip = true
+          else
+            if result.branches[name] == nil then
+              result.branches[name] = {}
+            end
+            table.insert(result.branches[name], remote)
+          end
         end
-        if result.branches[name] == nil then
-          result.branches[name] = {}
-        end
-        table.insert(result.branches[name], remote)
       end
     end
-    if not has_remote and result.branches[part] == nil then
+    if not skip and not has_remote and result.branches[part] == nil then
       result.branches[part] = {}
     end
-    ::continue::
   end
   return result
 end

--- a/tests/specs/neogit/lib/git/log_spec.lua
+++ b/tests/specs/neogit/lib/git/log_spec.lua
@@ -323,72 +323,72 @@ describe("lib.git.log.parse", function()
     end
   end)
 
-  it("lib.git.log.interprete extracts local branch name", function()
+  it("lib.git.log.branch_info extracts local branch name", function()
     local remotes = remote.list()
-    assert.are.same({ branches = { main = {} }, tags = {} }, subject.interprete("main", remotes))
+    assert.are.same({ branches = { main = {} }, tags = {} }, subject.branch_info("main", remotes))
     assert.are.same(
       { branches = { main = {}, develop = {} }, tags = {} },
-      subject.interprete("main, develop", remotes)
+      subject.branch_info("main, develop", remotes)
     )
   end)
 
-  it("lib.git.log.interprete extracts local & remote branch names", function()
+  it("lib.git.log.branch_info extracts local & remote branch names", function()
     local remotes = { "origin" }
     assert.are.same(
       { branches = { main = { "origin" } }, tags = {} },
-      subject.interprete("origin/main", remotes)
+      subject.branch_info("origin/main", remotes)
     )
     assert.are.same(
       { branches = { main = { "origin" }, develop = { "origin" } }, tags = {} },
-      subject.interprete("origin/main, origin/develop", remotes)
+      subject.branch_info("origin/main, origin/develop", remotes)
     )
     assert.are.same(
       { branches = { main = { "origin" }, develop = { "origin" } }, tags = {} },
-      subject.interprete("origin/main, main, origin/develop", remotes)
+      subject.branch_info("origin/main, main, origin/develop", remotes)
     )
     assert.are.same(
       { branches = { main = { "origin" }, develop = { "origin" }, foo = {} }, tags = {} },
-      subject.interprete("main, origin/main, origin/develop, develop, foo", remotes)
+      subject.branch_info("main, origin/main, origin/develop, develop, foo", remotes)
     )
   end)
 
-  it("lib.git.log.interprete can deal with multiple remotes", function()
+  it("lib.git.log.branch_info can deal with multiple remotes", function()
     local remotes = { "origin", "fork" }
     assert.are.same(
       { branches = { main = { "origin", "fork" } }, tags = {} },
-      subject.interprete("origin/main, main, fork/main", remotes)
+      subject.branch_info("origin/main, main, fork/main", remotes)
     )
     assert.are.same(
       { branches = { main = { "origin" }, develop = { "origin", "fork" }, foo = {} }, tags = {} },
-      subject.interprete("origin/main, develop, origin/develop, fork/develop, foo", remotes)
+      subject.branch_info("origin/main, develop, origin/develop, fork/develop, foo", remotes)
     )
   end)
 
-  it("lib.git.log.interprete can deal with slashes in branch names", function()
+  it("lib.git.log.branch_info can deal with slashes in branch names", function()
     local remotes = { "origin" }
     assert.are.same(
       { branches = { ["feature/xyz"] = { "origin" }, ["foo/bar/baz"] = {} }, tags = {} },
-      subject.interprete("feature/xyz, foo/bar/baz, origin/feature/xyz", remotes)
+      subject.branch_info("feature/xyz, foo/bar/baz, origin/feature/xyz", remotes)
     )
   end)
 
-  it("lib.git.log.interprete ignores HEAD references", function()
+  it("lib.git.log.branch_info ignores HEAD references", function()
     local remotes = { "origin", "fork" }
     assert.are.same(
       { branches = { main = { "origin", "fork" }, develop = {} }, tags = {} },
-      subject.interprete("origin/main, fork/main, develop, origin/HEAD, fork/HEAD", remotes)
+      subject.branch_info("origin/main, fork/main, develop, origin/HEAD, fork/HEAD", remotes)
     )
   end)
 
-  it("lib.git.log.interprete parses tags", function()
+  it("lib.git.log.branch_info parses tags", function()
     local remotes = { "origin" }
     assert.are.same({
       branches = {},
       tags = { "0.1.0" },
-    }, subject.interprete("tag: 0.1.0", remotes))
+    }, subject.branch_info("tag: 0.1.0", remotes))
     assert.are.same({
       branches = {},
       tags = { "0.5.7", "foo-bar" },
-    }, subject.interprete("tag: 0.5.7, tag: foo-bar", remotes))
+    }, subject.branch_info("tag: 0.5.7, tag: foo-bar", remotes))
   end)
 end)


### PR DESCRIPTION
## Problem
Currently if a commit contains a tag, the tag will be rendered in the log graph with the `NeogitBranch` highlight group. Worse, though, it can happen, that the tag will be misinterpreted as the remote name:

| Before | After |
|:--|:--|
|![graph-tags-before](https://github.com/NeogitOrg/neogit/assets/31999281/fabcfada-0a32-4586-94a0-e0dd217f3ecb)|![graph-tags-after](https://github.com/NeogitOrg/neogit/assets/31999281/285e9b9d-d3c2-42b3-b1cf-c101102469f0)|

## Tech Details

The `commit.ref_name` might also contain a tag name, which the log graph is currently rendering in the `NeogitBranch` highlight group. The refname of HEAD with a tag placed on it might look like this:

> HEAD -> main, tag: 1.0.0, origin/main, origin/HEAD

A refname of a tag not associated to any branch might look like this:

> tag: 1.0.0

This makes the parsing of `local_name`, `remote_name` a bit more sophisticated, since we don't know the exact order of them. Naive solution might be to just split `ref_name` by comma and pattern match:

* contains `tag: ...` -> `tag_name`
* contains `/` -> `remote_name`
* otherwise -> `local_name`

No Lua expert, maybe there is a better way to solve this =)