### PR TITLE
Remove dependency on cwd

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -67,7 +67,7 @@ function M.open(opts)
   end
 
   if not opts.cwd then
-    opts.cwd = require("neogit.lib.git.cli").git_root()
+    opts.cwd = require("neogit.lib.git.cli").git_root_of_cwd()
   end
 
   if not did_setup then
@@ -76,7 +76,7 @@ function M.open(opts)
     return
   end
 
-  if not cli.git_is_repository_sync(opts.cwd) then
+  if not cli.is_inside_worktree(opts.cwd) then
     if
       input.get_confirmation(
         string.format("Initialize repository in %s?", opts.cwd or vim.fn.getcwd()),
@@ -168,10 +168,6 @@ function M.complete(arglead)
   return vim.tbl_filter(function(arg)
     return arg:match("^" .. arglead)
   end, { "kind=", "cwd=", "commit" })
-end
-
-function M.get_repo()
-  return require("neogit.lib.git").repo
 end
 
 function M.get_log_file_path()

--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -9,6 +9,7 @@ local dv_lib = require("diffview.lib")
 local dv_utils = require("diffview.utils")
 
 local neogit = require("neogit")
+local repo = require("neogit.lib.git.repository")
 local status = require("neogit.status")
 local a = require("plenary.async")
 
@@ -35,47 +36,12 @@ local function cb(name)
   return string.format(":lua require('neogit.integrations.diffview').diffview_mappings['%s']()<CR>", name)
 end
 
----Resolves a cwd local file to git root relative
-local function root_prefix(git_root, cwd, path)
-  local t = {}
-  for part in string.gmatch(cwd .. "/" .. path, "[^/\\]+") do
-    if part == ".." then
-      if #t > 0 and t[#t] ~= ".." then
-        table.remove(t, #t)
-      else
-        table.insert(t, "..")
-      end
-    else
-      table.insert(t, part)
-    end
-  end
-
-  local git_root_parts = {}
-  for part in git_root:gmatch("[^/\\]+") do
-    table.insert(git_root_parts, part)
-  end
-
-  local s = {}
-  local skipping = true
-  for i = 1, #t do
-    if not skipping or git_root_parts[i] ~= t[i] then
-      table.insert(s, t[i])
-      skipping = false
-    end
-  end
-
-  path = table.concat(s, "/")
-  return path
-end
-
 local function get_local_diff_view(selected_file_name)
   local left = Rev(RevType.STAGE)
   local right = Rev(RevType.LOCAL)
-  local git_root = neogit.cli.git_root_sync()
 
   local function update_files()
     local files = {}
-    local repo = neogit.get_repo()
     local sections = {
       conflicting = {
         items = vim.tbl_filter(function(o)
@@ -89,9 +55,7 @@ local function get_local_diff_view(selected_file_name)
       files[kind] = {}
       for _, item in ipairs(section.items) do
         local file = {
-          -- use the repo.cwd instead of current as it may change since the
-          -- status was refreshed
-          path = root_prefix(git_root, repo.cwd, item.name),
+          path = item.name,
           status = item.mode and item.mode:sub(1, 1),
           stats = (item.diff and item.diff.stats) and {
             additions = item.diff.stats.additions or 0,
@@ -112,7 +76,7 @@ local function get_local_diff_view(selected_file_name)
   local files = update_files()
 
   local view = CDiffView {
-    git_root = git_root,
+    git_root = repo.git_root,
     left = left,
     right = right,
     files = files,

--- a/lua/neogit/lib/fs.lua
+++ b/lua/neogit/lib/fs.lua
@@ -3,11 +3,7 @@ local cli = require("neogit.lib.git.cli")
 local M = {}
 
 function M.relpath_from_repository(path)
-  local result = cli["ls-files"].others.cached.modified.deleted.full_name
-    .cwd("<current>")
-    .args(path)
-    .show_popup(false)
-    .call()
+  local result = cli["ls-files"].others.cached.modified.deleted.full_name.args(path).show_popup(false).call()
   return result.stdout[1]
 end
 

--- a/lua/neogit/lib/git/config.lua
+++ b/lua/neogit/lib/git/config.lua
@@ -70,10 +70,10 @@ end
 ---@type table<string, ConfigEntry>
 local config_cache = {}
 local cache_key = nil
-local git_root = cli.git_root()
 
 local function make_cache_key()
-  local stat = vim.loop.fs_stat(git_root .. "/.git/config")
+  local repo = require("neogit.lib.git.repository")
+  local stat = vim.loop.fs_stat(repo.git_root .. "/.git/config")
   if stat then
     return stat.mtime.sec
   end

--- a/lua/neogit/lib/git/index.lua
+++ b/lua/neogit/lib/git/index.lua
@@ -82,7 +82,7 @@ end
 ---@param opts table
 ---@return table
 function M.apply(patch, opts)
-  opts = opts or { reverse = false, cached = false, index = false, use_git_root = false }
+  opts = opts or { reverse = false, cached = false, index = false }
 
   local cmd = cli.apply
 
@@ -96,12 +96,6 @@ function M.apply(patch, opts)
 
   if opts.index then
     cmd = cmd.index
-  end
-
-  if opts.use_git_root then
-    local repository = require("neogit.lib.git.repository")
-
-    cmd = cmd.cwd(repository.git_root)
   end
 
   return cmd.with_patch(patch).call()

--- a/lua/neogit/lib/git/init.lua
+++ b/lua/neogit/lib/git/init.lua
@@ -32,7 +32,7 @@ M.init_repo = function()
   status.cwd_changed = true
   vim.cmd.lcd(directory)
 
-  if cli.git_is_repository_sync() then
+  if cli.is_inside_worktree() then
     if
       not input.get_confirmation(
         string.format("Reinitialize existing repository %s?", directory),

--- a/lua/neogit/lib/git/merge.lua
+++ b/lua/neogit/lib/git/merge.lua
@@ -31,20 +31,21 @@ function M.abort()
 end
 
 function M.update_merge_status(state)
-  if state.git_root == "" then
+  local repo = require("neogit.lib.git.repository")
+  if repo.git_root == "" then
     return
   end
 
   state.merge = { head = nil, msg = "", items = {} }
 
-  local merge_head = state.git_path("MERGE_HEAD")
+  local merge_head = repo:git_path("MERGE_HEAD")
   if not merge_head:exists() then
     return
   end
 
   state.merge.head = merge_head:read():match("([^\r\n]+)")
 
-  local message = state.git_path("MERGE_MSG")
+  local message = repo:git_path("MERGE_MSG")
   if message:exists() then
     state.merge.msg = message:read():match("([^\r\n]+)") -- we need \r? to support windows
   end

--- a/lua/neogit/lib/git/rebase.lua
+++ b/lua/neogit/lib/git/rebase.lua
@@ -46,15 +46,16 @@ function M.skip()
 end
 
 function M.update_rebase_status(state)
-  if state.git_root == "" then
+  local repo = require("neogit.lib.git.repository")
+  if repo.git_root == "" then
     return
   end
 
   state.rebase = { items = {}, head = nil, current = nil }
 
   local rebase_file
-  local rebase_merge = state.git_path("rebase-merge")
-  local rebase_apply = state.git_path("rebase-apply")
+  local rebase_merge = repo:git_path("rebase-merge")
+  local rebase_apply = repo:git_path("rebase-apply")
 
   if rebase_merge:exists() then
     rebase_file = rebase_merge

--- a/lua/neogit/lib/git/sequencer.lua
+++ b/lua/neogit/lib/git/sequencer.lua
@@ -20,23 +20,24 @@ function M.pick_or_revert_in_progress()
 end
 
 function M.update_sequencer_status(state)
+  local repo = require("neogit.lib.git.repository")
   state.sequencer = { items = {}, head = nil, head_oid = nil }
 
-  local revert_head = state.git_path("REVERT_HEAD")
-  local cherry_head = state.git_path("CHERRY_PICK_HEAD")
+  local revert_head = repo:git_path("REVERT_HEAD")
+  local cherry_head = repo:git_path("CHERRY_PICK_HEAD")
 
   if cherry_head:exists() then
     state.sequencer.head = "CHERRY_PICK_HEAD"
-    state.sequencer.head_oid = state.git_path("CHERRY_PICK_HEAD"):read()
+    state.sequencer.head_oid = repo:git_path("CHERRY_PICK_HEAD"):read()
     state.sequencer.cherry_pick = true
   elseif revert_head:exists() then
     state.sequencer.head = "REVERT_HEAD"
-    state.sequencer.head_oid = state.git_path("REVERT_HEAD"):read()
+    state.sequencer.head_oid = repo:git_path("REVERT_HEAD"):read()
     state.sequencer.revert = true
   end
 
-  local todo = state.git_path("sequencer/todo")
-  local orig = state.git_path("ORIG_HEAD")
+  local todo = repo:git_path("sequencer/todo")
+  local orig = repo:git_path("ORIG_HEAD")
   if todo:exists() then
     for line in todo:iter() do
       if not line:match("^#") then

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -160,7 +160,6 @@ local function update_status(state)
   else
     head.tag = { name = nil, distance = nil }
   end
-  state.cwd = cwd
   state.head = head
   state.upstream = upstream
   state.untracked.items = untracked_files

--- a/lua/neogit/popups/ignore/actions.lua
+++ b/lua/neogit/popups/ignore/actions.lua
@@ -51,7 +51,7 @@ M.shared_subdirectory = operation("ignore_subdirectory", function(popup)
 end)
 
 M.private_local = operation("ignore_private", function(popup)
-  local ignore_file = git.repo.git_path("info", "exclude")
+  local ignore_file = git.repo:git_path("info", "exclude")
   local rules = make_rules(popup, git.repo.git_root)
 
   add_rules(ignore_file, rules)

--- a/lua/neogit/popups/init.lua
+++ b/lua/neogit/popups/init.lua
@@ -90,7 +90,7 @@ function M.mappings_table()
             paths = util.filter_map(require("neogit.status").get_selection().items, function(v)
               return v.absolute_path
             end),
-            git_root = git.repo.state.git_root,
+            git_root = git.repo.git_root,
           }
         end),
       },

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -271,9 +271,6 @@ function Process:spawn(cb)
   -- An empty table is treated as an array
   self.env = self.env or {}
   self.env.TERM = "xterm-256color"
-  if self.cwd == "<current>" then
-    self.cwd = nil
-  end
 
   local start = vim.loop.now()
   self.start = start

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -537,7 +537,7 @@ local function refresh(which, reason)
   a.util.scheduler()
   local s, f, h = save_cursor_location()
 
-  if cli.git_root() ~= "" then
+  if cli.git_root_of_cwd() ~= "" then
     git.repo:refresh(which)
     refresh_status_buffer()
     vim.api.nvim_exec_autocmds("User", { pattern = "NeogitStatusRefreshed", modeline = false })
@@ -632,7 +632,9 @@ local function close(skip_close)
     M.status_buffer:close()
   end
 
-  M.watcher:stop()
+  if M.watcher then
+    M.watcher:stop()
+  end
   notification.delete_all()
   M.status_buffer = nil
   vim.o.autochdir = M.prev_autochdir
@@ -841,7 +843,7 @@ local stage = operation("stage", function()
           for _, hunk in ipairs(hunks) do
             -- Apply works for both tracked and untracked
             local patch = git.index.generate_patch(item, hunk, hunk.from, hunk.to)
-            git.index.apply(patch, { cached = true, use_git_root = true })
+            git.index.apply(patch, { cached = true })
           end
         else
           git.status.stage { item.name }
@@ -850,10 +852,7 @@ local stage = operation("stage", function()
         if #hunks > 0 then
           for _, hunk in ipairs(hunks) do
             -- Apply works for both tracked and untracked
-            git.index.apply(
-              git.index.generate_patch(item, hunk, hunk.from, hunk.to),
-              { cached = true, use_git_root = true }
-            )
+            git.index.apply(git.index.generate_patch(item, hunk, hunk.from, hunk.to), { cached = true })
           end
         else
           table.insert(files, item.name)
@@ -901,7 +900,7 @@ local unstage = operation("unstage", function()
             -- Apply works for both tracked and untracked
             git.index.apply(
               git.index.generate_patch(item, hunk, hunk.from, hunk.to, true),
-              { cached = true, reverse = true, use_git_root = true }
+              { cached = true, reverse = true }
             )
           end
         else
@@ -967,9 +966,9 @@ local discard = operation("discard", function()
 
             if section_name == "staged" then
               --- Apply both to the worktree and the staging area
-              git.index.apply(patch, { index = true, reverse = true, use_git_root = true })
+              git.index.apply(patch, { index = true, reverse = true })
             else
-              git.index.apply(patch, { reverse = true, use_git_root = true })
+              git.index.apply(patch, { reverse = true })
             end
           end)
         end
@@ -978,7 +977,7 @@ local discard = operation("discard", function()
         table.insert(t, function()
           if section_name == "untracked" then
             a.util.scheduler()
-            vim.fn.delete(cli.git_root() .. "/" .. item.name)
+            vim.fn.delete(git.repo.git_root .. "/" .. item.name)
           elseif section_name == "unstaged" then
             git.index.checkout { item.name }
           elseif section_name == "staged" then
@@ -1238,7 +1237,6 @@ local cmd_func_map = function()
       end
     end,
     ["GoToFile"] = a.void(function()
-      -- local repo_root = cli.git_root()
       a.util.scheduler()
       local section, item = get_current_section_item()
       if not section then
@@ -1448,7 +1446,7 @@ function M.create(kind, cwd)
       refresh(true, "Buffer.create")
     end,
     after = function()
-      M.watcher = watcher.new(git.repo.git_path():absolute())
+      M.watcher = watcher.new(git.repo:git_path():absolute())
     end,
   }
 end

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,7 +91,7 @@ describe("git cli", function()
     it(
       "finds the correct git root for a non symlinked directory",
       in_prepared_repo(function(root_dir)
-        local detected_root_dir = git_cli.git_root()
+        local detected_root_dir = git_cli.git_root_of_cwd()
         eq(detected_root_dir, root_dir)
       end)
     )

--- a/tests/specs/neogit/lib/git/cli_spec.lua
+++ b/tests/specs/neogit/lib/git/cli_spec.lua
@@ -8,7 +8,7 @@ describe("git cli", function()
     it(
       "finds the correct git root for a non symlinked directory",
       in_prepared_repo(function(root_dir)
-        local detected_root_dir = git_cli.git_root()
+        local detected_root_dir = git_cli.git_root_of_cwd()
         eq(detected_root_dir, root_dir)
       end)
     )
@@ -35,7 +35,7 @@ describe("git cli", function()
         vim.fn.system(cmd)
         vim.api.nvim_set_current_dir(symlink_dir)
 
-        local detected_root_dir = git_cli.git_root()
+        local detected_root_dir = git_cli.git_root_of_cwd()
         eq(detected_root_dir, git_dir)
       end)
     )

--- a/tests/specs/neogit/popups/branch_spec.lua
+++ b/tests/specs/neogit/popups/branch_spec.lua
@@ -172,6 +172,7 @@ describe("branch popup", function()
         input.confirmed = true
 
         local remote = harness.prepare_repository()
+        async.util.block_on(status.reset)
         util.system("git remote add upstream " .. remote)
         util.system([[
           git stash --include-untracked

--- a/tests/specs/neogit/popups/remote_spec.lua
+++ b/tests/specs/neogit/popups/remote_spec.lua
@@ -1,4 +1,5 @@
 require("plenary.async").tests.add_to_env()
+local async = require("plenary.async")
 local eq = assert.are.same
 local operations = require("neogit.operations")
 local harness = require("tests.util.git_harness")
@@ -19,6 +20,7 @@ describe("remote popup", function()
     in_prepared_repo(function()
       local remote_a = harness.prepare_repository()
       local remote_b = harness.prepare_repository()
+      async.util.block_on(status.reset)
 
       input.values = { "foo", remote_a }
       act("Ma")


### PR DESCRIPTION
This pull request fixes #931 and fixes #442 by ensuring the independence of nearly all library functions from the current working directory (cwd).

Specifically, this pertains to functions that directly or indirectly use cwd, which can change anytime, either manually by the user or automatically through plugins. Cwd dependent functions make it difficult to reason about the state of Neogit and potentially lead to numerous bugs. Throughout the codebase, you can observe various attempts to circumvent this issue, often involving the tracking of the cwd via `state.cwd`.

Notably, all functions in `neogit.lib.git.cli` are dependent on the cwd, with `require("neogit.lib.git.cli").git_root()` being a noteworthy example.

This pull request aims to eliminate all cwd dependencies by designating `require("neogit.lib.git.repository").git_root` as the source of truth for the git root that Neogit is targeting. Unlike the cwd, which can change at any point, `repository.git_root` only updates through `repository.refresh()` triggered by manual user intervention (e.g., `Ctrl+R` or `:Neogit`) and should - hopefully - also invalidate all other state which depends on the git root.

Key changes in this pull request include:
- Ensuring that all `cli` functions are executed with `cwd = repository.git_root`. This change is particularly impactful as it ensures that all cwd-relative file paths returned by `git` do not need to be converted to paths relative to the git root, as `cwd == git_root` always holds.
- Replacing all instances of `cli.git_root()` with `repository.git_root` in the codebase to maintain consistency.
- Renaming `cli.git_root()` to `cli.git_root_of_cwd()` to discourage its use and prevent undoing the modifications introduced by this pull request.
- Removing workaround code related to changing cwd, such as `diffview.root_prefix()`, `repository.cwd`, and the `use_git_root` argument of hunk operations.

Smaller changes include:
- Renaming `git_is_repository_sync` to `is_inside_worktree` for clarity.
- Removing `neogit.get_repo()` due to its solitary use.
- Eliminating unused functions `cli.git_root_sync()` and `cli.git_dir_path_sync()`.
- Making `repository.git_path` a function of the module rather than part of the state, as `git_path` depends on `git_root`.

Additionally, two tests that relied on Neogit being cwd dependent were adjusted to ensure that `status.reset()` is called after the cwd has been changed.