### PR TITLE
Standardize prompt prefixes

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -171,6 +171,10 @@ Finder.__index = Finder
 ---@param opts FinderOpts
 ---@return Finder
 function Finder:new(opts)
+  if opts.prompt_prefix then
+    opts.prompt_prefix = string.format(" %s > ", opts.prompt_prefix)
+  end
+
   local this = {
     opts = vim.tbl_deep_extend("keep", opts, default_opts()),
     entries = {},
@@ -210,7 +214,7 @@ function Finder:find(on_select)
   elseif config.check_integration("fzf_lua") then
     local fzf_lua = require("fzf-lua")
     fzf_lua.fzf_exec(self.entries, {
-      prompt = self.opts.prompt_prefix,
+      prompt = string.format(" %s > ", self.opts.prompt_prefix),
       fzf_opts = fzf_opts(self.opts),
       winopts = {
         height = self.opts.layout_config.height,
@@ -219,7 +223,7 @@ function Finder:find(on_select)
     })
   else
     vim.ui.select(self.entries, {
-      prompt = self.opts.prompt_prefix,
+      prompt = string.format(" %s > ", self.opts.prompt_prefix),
       format_item = function(entry)
         return entry
       end,

--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -158,7 +158,7 @@ function M.set_pushRemote()
   elseif pushDefault:is_set() then
     pushRemote = pushDefault:read()
   else
-    pushRemote = FuzzyFinderBuffer.new(remotes):open_async { prompt_prefix = "set pushRemote > " }
+    pushRemote = FuzzyFinderBuffer.new(remotes):open_async { prompt_prefix = "set pushRemote" }
   end
 
   if pushRemote then

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -82,7 +82,7 @@ M.checkout_local_branch = operation("checkout_local_branch", function(popup)
   end)
 
   local target = FuzzyFinderBuffer.new(util.merge(local_branches, remote_branches)):open_async {
-    prompt_prefix = " branch > ",
+    prompt_prefix = "branch",
   }
 
   if target then
@@ -116,7 +116,7 @@ M.checkout_create_branch = operation("checkout_create_branch", function()
   end
   name, _ = name:gsub("%s", "-")
 
-  local base_branch = FuzzyFinderBuffer.new(branches):open_async { prompt_prefix = " base branch > " }
+  local base_branch = FuzzyFinderBuffer.new(branches):open_async { prompt_prefix = "base branch" }
   if not base_branch then
     return
   end
@@ -180,7 +180,7 @@ M.reset_branch = operation("reset_branch", function()
   local current = git.branch.current()
   local branches = git.branch.get_all_branches(false)
   local to = FuzzyFinderBuffer.new(branches):open_async {
-    prompt_prefix = string.format(" reset %s to > ", current),
+    prompt_prefix = string.format("reset %s to", current),
   }
 
   if not to then

--- a/lua/neogit/popups/branch_config/actions.lua
+++ b/lua/neogit/popups/branch_config/actions.lua
@@ -46,7 +46,7 @@ function M.merge_config(branch)
   local branches = util.merge(local_branches, remote_branches)
 
   return a.void(function(popup, c)
-    local target = FuzzyFinderBuffer.new(branches):open_async { prompt_prefix = "Upstream > " }
+    local target = FuzzyFinderBuffer.new(branches):open_async { prompt_prefix = "upstream" }
     if not target then
       return
     end

--- a/lua/neogit/popups/fetch/actions.lua
+++ b/lua/neogit/popups/fetch/actions.lua
@@ -9,7 +9,7 @@ local util = require("neogit.lib.util")
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 
 local function select_remote()
-  return FuzzyFinderBuffer.new(git.remote.list()):open_async { prompt_prefix = "remote > " }
+  return FuzzyFinderBuffer.new(git.remote.list()):open_async { prompt_prefix = "remote" }
 end
 
 local function fetch_from(name, remote, branch, args)
@@ -86,7 +86,7 @@ function M.fetch_another_branch(popup)
   end)
 
   local branch = FuzzyFinderBuffer.new(branches):open_async {
-    prompt_prefix = remote .. "/{branch} > ",
+    prompt_prefix = remote .. "/{branch}",
   }
   if not branch then
     return
@@ -107,7 +107,7 @@ function M.fetch_refspec(popup)
   end)
   notification.delete_all()
 
-  local refspec = FuzzyFinderBuffer.new(refspecs):open_async { prompt_prefix = "refspec > " }
+  local refspec = FuzzyFinderBuffer.new(refspecs):open_async { prompt_prefix = "refspec" }
   if not refspec then
     return
   end

--- a/lua/neogit/popups/ignore/actions.lua
+++ b/lua/neogit/popups/ignore/actions.lua
@@ -22,7 +22,7 @@ end
 ---@param rules string[]
 local function add_rules(path, rules)
   local selected = FuzzyFinderBuffer.new(rules)
-    :open_async { allow_multi = true, prompt_prefix = " File or pattern to ignore > " }
+    :open_async { allow_multi = true, prompt_prefix = "File or pattern to ignore" }
 
   if not selected or #selected == 0 then
     return

--- a/lua/neogit/popups/pull/actions.lua
+++ b/lua/neogit/popups/pull/actions.lua
@@ -49,7 +49,7 @@ function M.from_upstream(popup)
   if not upstream then
     set_upstream = true
     upstream = FuzzyFinderBuffer.new(git.branch.get_remote_branches()):open_async {
-      prompt_prefix = "set upstream > ",
+      prompt_prefix = "set upstream",
     }
 
     if not upstream then
@@ -63,7 +63,7 @@ end
 
 function M.from_elsewhere(popup)
   local target = FuzzyFinderBuffer.new(git.branch.get_all_branches(false))
-    :open_async { prompt_prefix = "pull > " }
+    :open_async { prompt_prefix = "pull" }
   if not target then
     return
   end

--- a/lua/neogit/popups/push/actions.lua
+++ b/lua/neogit/popups/push/actions.lua
@@ -57,7 +57,7 @@ function M.to_upstream(popup)
     set_upstream = true
     branch = git.branch.current()
     remote = git.branch.upstream_remote()
-      or FuzzyFinderBuffer.new(git.remote.list()):open_async { prompt_prefix = "remote > " }
+      or FuzzyFinderBuffer.new(git.remote.list()):open_async { prompt_prefix = "remote" }
   end
 
   if remote then
@@ -69,7 +69,7 @@ end
 
 function M.to_elsewhere(popup)
   local target = FuzzyFinderBuffer.new(git.branch.get_remote_branches()):open_async {
-    prompt_prefix = "push > ",
+    prompt_prefix = "push",
   }
 
   if target then
@@ -87,7 +87,7 @@ function M.push_other(popup)
     table.insert(sources, 1, popup.state.env.commit)
   end
 
-  local source = FuzzyFinderBuffer.new(sources):open_async { prompt_prefix = "push > " }
+  local source = FuzzyFinderBuffer.new(sources):open_async { prompt_prefix = "push" }
   if not source then
     return
   end
@@ -98,7 +98,7 @@ function M.push_other(popup)
   end
 
   local destination = FuzzyFinderBuffer.new(destinations)
-    :open_async { prompt_prefix = "push " .. source .. " to > " }
+    :open_async { prompt_prefix = "push " .. source .. " to" }
   if not destination then
     return
   end
@@ -114,7 +114,7 @@ function M.push_tags(popup)
   if #remotes == 1 then
     remote = remotes[1]
   else
-    remote = FuzzyFinderBuffer.new(remotes):open_async { prompt_prefix = "push tags to > " }
+    remote = FuzzyFinderBuffer.new(remotes):open_async { prompt_prefix = "push tags to" }
   end
 
   if remote then

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -62,7 +62,7 @@ end
 ---@param _ table
 function M.prune(_)
   local selected_remote = FuzzyFinderBuffer.new(git.remote.list()):open_async {
-    prompt_prefix = " Prune tags using remote > ",
+    prompt_prefix = "Prune tags using remote",
   }
 
   if (selected_remote or "") == "" then


### PR DESCRIPTION
Consolidate the formatting in builder so all callers just need to pass in text.