### PR TITLE
Allow to open pull popup from within log view

### DIFF
--- a/lua/neogit/buffers/log_view/init.lua
+++ b/lua/neogit/buffers/log_view/init.lua
@@ -51,6 +51,9 @@ function M:open()
         [popups.mapping_for("CommitPopup")] = popups.open("commit", function(p)
           p { commit = self.buffer.ui:get_commit_under_cursor() }
         end),
+        [popups.mapping_for("PullPopup")] = popups.open("pull", function(p)
+          p { commit = self.buffer.ui:get_commit_under_cursor() }
+        end),
         [popups.mapping_for("PushPopup")] = popups.open("push", function(p)
           p { commit = self.buffer.ui:get_commit_under_cursor() }
         end),
@@ -84,6 +87,9 @@ function M:open()
           p { commits = { self.buffer.ui:get_commit_under_cursor() } }
         end),
         [popups.mapping_for("CommitPopup")] = popups.open("commit", function(p)
+          p { commit = self.buffer.ui:get_commit_under_cursor() }
+        end),
+        [popups.mapping_for("PullPopup")] = popups.open("pull", function(p)
           p { commit = self.buffer.ui:get_commit_under_cursor() }
         end),
         [popups.mapping_for("PushPopup")] = popups.open("push", function(p)


### PR DESCRIPTION
Another small thing, that worked in Magit: When pressing `p` in the log graph view you could open the "pull" popup. On my setup this fails with:

![image](https://github.com/NeogitOrg/neogit/assets/31999281/bd2f2302-b13f-42e9-9279-1d4f712dc347)

Added this open to the pop up mappings in `log_view`:
![pull-popup gif](https://github.com/NeogitOrg/neogit/assets/31999281/deaceea4-3112-4306-9cca-f862adff7ead)
