### PR TITLE
FIX: Properly render HEAD with `NeogitBranchHead` highlight group

### DIFF
--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -113,13 +113,12 @@ M.CommitEntry = Component.new(function(commit, args)
 
   -- Parse out ref names
   if args.decorate and commit.ref_name ~= "" then
-    local ref_name, _ = commit.ref_name:gsub("HEAD %-> ", "")
-    local is_head = string.match(commit.ref_name, "HEAD %->") ~= nil
-    local branch_highlight = is_head and "NeogitBranchHead" or "NeogitBranch"
-
-    local info = git.log.branch_info(ref_name, git.remote.list())
+    local info = git.log.branch_info(commit.ref_name, git.remote.list())
     for _, branch in ipairs(info.untracked) do
-      table.insert(ref, text(branch, { highlight = "NeogitBranch" }))
+      table.insert(
+        ref,
+        text(branch, { highlight = info.head == branch and "NeogitBranchHead" or "NeogitBranch" })
+      )
       table.insert(ref, text(" "))
     end
     for branch, remotes in pairs(info.tracked) do
@@ -129,7 +128,10 @@ M.CommitEntry = Component.new(function(commit, args)
       if #remotes > 1 then
         table.insert(ref, text("{" .. table.concat(remotes, ",") .. "}/", { highlight = "NeogitRemote" }))
       end
-      table.insert(ref, text(branch, { highlight = branch_highlight }))
+      table.insert(
+        ref,
+        text(branch, { highlight = info.head == branch and "NeogitBranchHead" or "NeogitBranch" })
+      )
       table.insert(ref, text(" "))
     end
     for _, tag in pairs(info.tags) do

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -440,8 +440,8 @@ end
 
 ---@class CommitBranchInfo
 ---@field head string? The name of the local branch, which is currently checked out (if any)
----@field untracked string[] List of local branches on without any remote counterparts
----@field tracked table<string, string[]>  Mapping from (local) branch names to list of remotes where this branch is present
+---@field locals table<string,boolean> Set of local branch names
+---@field remotes table<string, string[]> table<string, string[]> Mapping from (local) branch names to list of remotes where this branch is present
 ---@field tags string[] List of tags placed on this commit
 
 --- Parse information of branches, tags and remotes from a given commit's ref output
@@ -454,49 +454,46 @@ function M.branch_info(ref, remotes)
   local parts = vim.split(ref, ", ")
   local result = {
     head = nil,
-    untracked = {},
-    tracked = {},
+    locals = {},
+    remotes = {},
     tags = {},
   }
-  local untracked = {}
-  for _, part in ipairs(parts) do
+
+  for _, name in pairs(parts) do
     local skip = false
-    if part:match("^tag: .*") ~= nil then
-      local tag = part:gsub("tag: ", "")
+    if name:match("^tag: .*") ~= nil then
+      local tag = name:gsub("tag: ", "")
       table.insert(result.tags, tag)
-      -- No need to annotate tags with remotes, probably too cluttered
       skip = true
     end
-    if part:match("HEAD %-> ") then
-      part = part:gsub("HEAD %-> ", "")
-      result.head = part
+
+    if name:match("HEAD %-> ") then
+      name = name:gsub("HEAD %-> ", "")
+      result.head = name
     end
 
-    local has_remote = false
-    for _, remote in ipairs(remotes) do
+    local remote = nil
+    for _, r in ipairs(remotes) do
       if not skip then
-        if part:match("^" .. remote .. "/") then
-          has_remote = true
-          local name = part:gsub("^" .. remote .. "/", "")
+        if name:match("^" .. r .. "/") then
+          name = name:gsub("^" .. r .. "/", "")
           if name == "HEAD" then
             skip = true
           else
-            if result.tracked[name] == nil then
-              result.tracked[name] = {}
-            end
-            table.insert(result.tracked[name], remote)
+            remote = r
           end
         end
       end
     end
-    -- if not skip and not has_remote and result.tracked[part] == nil then
-    if not skip and not has_remote then
-      table.insert(untracked, part)
-    end
-  end
-  for _, branch in ipairs(untracked) do
-    if result.tracked[branch] == nil then
-      table.insert(result.untracked, branch)
+    if not skip then
+      if remote ~= nil then
+        if result.remotes[name] == nil then
+          result.remotes[name] = {}
+        end
+        table.insert(result.remotes[name], remote)
+      else
+        result.locals[name] = true
+      end
     end
   end
   return result

--- a/tests/specs/neogit/lib/git/log_spec.lua
+++ b/tests/specs/neogit/lib/git/log_spec.lua
@@ -331,6 +331,23 @@ describe("lib.git.log.parse", function()
       subject.branch_info("main, develop", remotes)
     )
   end)
+  it("lib.git.log.branch_info extracts head", function()
+    local remotes = remote.list()
+    assert.are.same(
+      { head = "main", untracked = { "main" }, tracked = {}, tags = {} },
+      subject.branch_info("HEAD -> main", remotes)
+    )
+    assert.are.same(
+      { head = "develop", untracked = { "main", "develop" }, tracked = {}, tags = {} },
+      subject.branch_info("main, HEAD -> develop", remotes)
+    )
+    assert.are.same({
+      head = "foo",
+      untracked = { "foo" },
+      tracked = { develop = { "origin" }, main = { "origin" } },
+      tags = {},
+    }, subject.branch_info("HEAD -> foo, origin/HEAD, main, origin/main, origin/develop", { "origin" }))
+  end)
 
   it("lib.git.log.branch_info extracts local & remote branch names", function()
     local remotes = { "origin" }


### PR DESCRIPTION
Sorry I just noticed, I introduced a small bug in my previous PR #934, where local checked out branches are not rendered with the `NeogitBranchHead`. With a user config of:

```lua
local blue = "#bae7ff"
local remote = "#b4eeb2"

vim.api.nvim_set_hl(0, "NeogitBranch", { fg = blue, bold = true })
vim.api.nvim_set_hl(0, "NeogitBranchHead", { fg = blue, bold = true, underline = true })
vim.api.nvim_set_hl(0, "NeogitRemote", { fg = remote, italic = true })
```

and a branch called `foo` checked out, this is what happens:

|Before|After|
|:--|:--|
|![before](https://github.com/NeogitOrg/neogit/assets/31999281/268f9c5d-71da-424c-a5f1-520230c04581)|![after](https://github.com/NeogitOrg/neogit/assets/31999281/7268f654-c7cf-4a7b-bb15-644a2f2c6a97)|

This PR should fix this now =)