### PR TITLE
More `Neogit*` Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Neogit emits the following events:
 | `NeogitBranchRename`    | Branch was renamed                       | `{ branch_name: string, new_name: string }`     |
 | `NeogitRebase`        | A rebase finished                        | `{ commit: string, status: "ok"\|"conflict" }`    |
 | `NeogitReset`         | A branch was reset to a certain commit   | `{ commit: string, mode: "soft"\|"mixed"\|"hard"\|"keep"\|"index" }` |
+| `NeogitTagCreate`     | A tag was placed on a certain commit     | `{ name: string, ref: string }`                   |
+| `NeogitTagDelete`     | A tag was removed                        | `{ name: string }`                                |
 
 You can listen to the events using the following code:
 

--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Neogit emits the following events:
 | `NeogitBranchCheckout`  | Branch was checked out                   | `{ branch_name: string }`                       |
 | `NeogitBranchReset`     | Branch was reset to a commit/branch      | `{ branch_name: string, resetting_to: string }` |
 | `NeogitBranchRename`    | Branch was renamed                       | `{ branch_name: string, new_name: string }`     |
+| `NeogitRebase`        | A rebase finished                        | `{ commit: string, status: "ok"\|"conflict" }`    |
 
 You can listen to the events using the following code:
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Neogit emits the following events:
 | `NeogitReset`         | A branch was reset to a certain commit   | `{ commit: string, mode: "soft"\|"mixed"\|"hard"\|"keep"\|"index" }` |
 | `NeogitTagCreate`     | A tag was placed on a certain commit     | `{ name: string, ref: string }`                   |
 | `NeogitTagDelete`     | A tag was removed                        | `{ name: string }`                                |
+| `NeogitCherryPick`    | One or more commits were cherry-picked    | `{ commits: string[] }`                          |
 
 You can listen to the events using the following code:
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Neogit emits the following events:
 | `NeogitTagCreate`     | A tag was placed on a certain commit     | `{ name: string, ref: string }`                   |
 | `NeogitTagDelete`     | A tag was removed                        | `{ name: string }`                                |
 | `NeogitCherryPick`    | One or more commits were cherry-picked    | `{ commits: string[] }`                          |
+| `NeogitMerge`         | A merge finished                          | `{ branch: string, args = string[], status: "ok"\|"conflict" }` |
 
 You can listen to the events using the following code:
 

--- a/README.md
+++ b/README.md
@@ -385,13 +385,18 @@ See the built-in documentation for a comprehensive list of highlight groups. If 
 
 Neogit emits the following events:
 
-| Event                   | Description                      |
-|-------------------------|----------------------------------|
-| `NeogitStatusRefreshed` | Status has been reloaded         |
-| `NeogitCommitComplete`  | Commit has been created          |
-| `NeogitPushComplete`    | Push has completed               |
-| `NeogitPullComplete`    | Pull has completed               |
-| `NeogitFetchComplete`   | Fetch has completed              |
+| Event                   | Description                              | Event Data                                      |
+|-------------------------|------------------------------------------|-------------------------------------------------|
+| `NeogitStatusRefreshed` | Status has been reloaded                 | `{}`                                            |
+| `NeogitCommitComplete`  | Commit has been created                  | `{}`                                            |
+| `NeogitPushComplete`    | Push has completed                       | `{}`                                            |
+| `NeogitPullComplete`    | Pull has completed                       | `{}`                                            |
+| `NeogitFetchComplete`   | Fetch has completed                      | `{}`                                            |
+| `NeogitBranchCreate`    | Branch was created, starting from `base` | `{ branch_name: string, base: string? }`        |
+| `NeogitBranchDelete`    | Branch was deleted                       | `{ branch_name: string }`                       |
+| `NeogitBranchCheckout`  | Branch was checked out                   | `{ branch_name: string }`                       |
+| `NeogitBranchReset`     | Branch was reset to a commit/branch      | `{ branch_name: string, resetting_to: string }` |
+| `NeogitBranchRename`    | Branch was renamed                       | `{ branch_name: string, new_name: string }`     |
 
 You can listen to the events using the following code:
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Neogit emits the following events:
 | `NeogitBranchReset`     | Branch was reset to a commit/branch      | `{ branch_name: string, resetting_to: string }` |
 | `NeogitBranchRename`    | Branch was renamed                       | `{ branch_name: string, new_name: string }`     |
 | `NeogitRebase`        | A rebase finished                        | `{ commit: string, status: "ok"\|"conflict" }`    |
+| `NeogitReset`         | A branch was reset to a certain commit   | `{ commit: string, mode: "soft"\|"mixed"\|"hard"\|"keep"\|"index" }` |
 
 You can listen to the events using the following code:
 

--- a/lua/neogit/client.lua
+++ b/lua/neogit/client.lua
@@ -96,6 +96,7 @@ end
 
 ---@param cmd any
 ---@param opts WrapOpts
+---@return integer code of `cmd`
 function M.wrap(cmd, opts)
   local notification = require("neogit.lib.notification")
   local a = require("plenary.async")
@@ -119,6 +120,7 @@ function M.wrap(cmd, opts)
       notification.warn(opts.msg.fail, { dismiss = true })
     end
   end
+  return result.code
 end
 
 return M

--- a/lua/neogit/lib/git/cherry_pick.lua
+++ b/lua/neogit/lib/git/cherry_pick.lua
@@ -4,10 +4,16 @@ local util = require("neogit.lib.util")
 
 local M = {}
 
+local function fire_cherrypick_event(data)
+  vim.api.nvim_exec_autocmds("User", { pattern = "NeogitCherryPick", modeline = false, data = data })
+end
+
 function M.pick(commits, args)
   local result = cli["cherry-pick"].arg_list(util.merge(args, commits)).call()
   if result.code ~= 0 then
     notification.error("Cherry Pick failed. Resolve conflicts before continuing")
+  else
+    fire_cherrypick_event { commits = commits }
   end
 end
 
@@ -21,6 +27,8 @@ function M.apply(commits, args)
   local result = cli["cherry-pick"].no_commit.arg_list(util.merge(args, commits)).call()
   if result.code ~= 0 then
     notification.error("Cherry Pick failed. Resolve conflicts before continuing")
+  else
+    fire_cherrypick_event { commits = commits }
   end
 end
 

--- a/lua/neogit/lib/git/merge.lua
+++ b/lua/neogit/lib/git/merge.lua
@@ -12,13 +12,19 @@ local function merge_command(cmd)
   return cmd.env(envs).show_popup(true):in_pty(true).call(true)
 end
 
+local function fire_merge_event(data)
+  vim.api.nvim_exec_autocmds("User", { pattern = "NeogitMerge", modeline = false, data = data })
+end
+
 function M.merge(branch, args)
   a.util.scheduler()
   local result = merge_command(cli.merge.args(branch).arg_list(args))
   if result.code ~= 0 then
     notification.error("Merging failed. Resolve conflicts before continuing")
+    fire_merge_event { branch = branch, args = args, status = "conflict" }
   else
     notification.info("Merged '" .. branch .. "' into '" .. branch_lib.current() .. "'")
+    fire_merge_event { branch = branch, args = args, status = "ok" }
   end
 end
 

--- a/lua/neogit/lib/git/rebase.lua
+++ b/lua/neogit/lib/git/rebase.lua
@@ -6,6 +6,10 @@ local M = {}
 
 local a = require("plenary.async")
 
+local function fire_rebase_event(data)
+  vim.api.nvim_exec_autocmds("User", { pattern = "NeogitRebase", modeline = false, data = data })
+end
+
 local function rebase_command(cmd)
   local git = require("neogit.lib.git")
   cmd = cmd or git.cli.rebase
@@ -19,8 +23,10 @@ function M.rebase_interactive(commit, args)
   local result = rebase_command(git.cli.rebase.interactive.args(commit).arg_list(args))
   if result.code ~= 0 then
     notification.error("Rebasing failed. Resolve conflicts before continuing")
+    fire_rebase_event { commit = commit, status = "conflict" }
   else
     notification.info("Rebased successfully")
+    fire_rebase_event { commit = commit, status = "ok" }
   end
 end
 
@@ -30,8 +36,10 @@ function M.rebase_onto(branch, args)
   local result = rebase_command(git.cli.rebase.args(branch).arg_list(args))
   if result.code ~= 0 then
     notification.error("Rebasing failed. Resolve conflicts before continuing")
+    fire_rebase_event("conflict")
   else
     notification.info("Rebased onto '" .. branch .. "'")
+    fire_rebase_event("ok")
   end
 end
 

--- a/lua/neogit/lib/git/reset.lua
+++ b/lua/neogit/lib/git/reset.lua
@@ -4,6 +4,10 @@ local a = require("plenary.async")
 
 local M = {}
 
+local function fire_reset_event(data)
+  vim.api.nvim_exec_autocmds("User", { pattern = "NeogitReset", modeline = false, data = data })
+end
+
 function M.mixed(commit)
   a.util.scheduler()
 
@@ -12,6 +16,7 @@ function M.mixed(commit)
     notification.error("Reset Failed")
   else
     notification.info("Reset to " .. commit)
+    fire_reset_event { commit = commit, mode = "mixed" }
   end
 end
 
@@ -23,6 +28,7 @@ function M.soft(commit)
     notification.error("Reset Failed")
   else
     notification.info("Reset to " .. commit)
+    fire_reset_event { commit = commit, mode = "soft" }
   end
 end
 
@@ -34,6 +40,7 @@ function M.hard(commit)
     notification.error("Reset Failed")
   else
     notification.info("Reset to " .. commit)
+    fire_reset_event { commit = commit, mode = "hard" }
   end
 end
 
@@ -45,6 +52,7 @@ function M.keep(commit)
     notification.error("Reset Failed")
   else
     notification.info("Reset to " .. commit)
+    fire_reset_event { commit = commit, mode = "keep" }
   end
 end
 
@@ -56,6 +64,7 @@ function M.index(commit)
     notification.error("Reset Failed")
   else
     notification.info("Reset to " .. commit)
+    fire_reset_event { commit = commit, mode = "index" }
   end
 end
 

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -10,6 +10,10 @@ local operation = require("neogit.operations")
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 local BranchConfigPopup = require("neogit.popups.branch_config")
 
+local function fire_branch_event(pattern, data)
+  vim.api.nvim_exec_autocmds("User", { pattern = pattern, modeline = false, data = data })
+end
+
 local function parse_remote_branch_name(ref)
   local offset = ref:find("/")
   if not offset then
@@ -69,6 +73,7 @@ M.checkout_branch_revision = operation("checkout_branch_revision", function(popu
   end
 
   git.cli.checkout.branch(selected_branch).arg_list(popup:get_arguments()).call_sync():trim()
+  fire_branch_event("NeogitBranchCheckout", { branch_name = selected_branch })
 end)
 
 M.checkout_local_branch = operation("checkout_local_branch", function(popup)
@@ -91,6 +96,7 @@ M.checkout_local_branch = operation("checkout_local_branch", function(popup)
     elseif target then
       git.cli.checkout.branch(target).arg_list(popup:get_arguments()).call_sync()
     end
+    fire_branch_event("NeogitBranchCheckout", { branch_name = target })
   end
 end)
 
@@ -101,6 +107,7 @@ M.checkout_recent_branch = operation("checkout_recent_branch", function(popup)
   end
 
   git.cli.checkout.branch(selected_branch).arg_list(popup:get_arguments()).call_sync():trim()
+  fire_branch_event("NeogitBranchCheckout", { branch_name = selected_branch })
 end)
 
 M.checkout_create_branch = operation("checkout_create_branch", function()
@@ -122,6 +129,8 @@ M.checkout_create_branch = operation("checkout_create_branch", function()
   end
 
   git.cli.checkout.new_branch_with_start_point(name, base_branch).call_sync()
+  fire_branch_event("NeogitBranchCreate", { branch_name = name, base = base_branch })
+  fire_branch_event("NeogitBranchCheckout", { branch_name = name })
 end)
 
 M.create_branch = operation("create_branch", function()
@@ -132,6 +141,7 @@ M.create_branch = operation("create_branch", function()
 
   name, _ = name:gsub("%s", "-")
   git.branch.create(name)
+  fire_branch_event("NeogitBranchCreate", { branch_name = name })
 end)
 
 M.configure_branch = operation("configure_branch", function()
@@ -164,6 +174,7 @@ M.rename_branch = operation("rename_branch", function()
   git.cli.branch.move.args(selected_branch, new_name).call()
 
   notification.info(string.format("Renamed '%s' to '%s'", selected_branch, new_name))
+  fire_branch_event("NeogitBranchRename", { branch_name = selected_branch, new_name = new_name })
 end)
 
 M.reset_branch = operation("reset_branch", function()
@@ -192,6 +203,7 @@ M.reset_branch = operation("reset_branch", function()
   git.log.update_ref(git.branch.current_full_name(), to)
 
   notification.info(string.format("Reset '%s' to '%s'", current, to))
+  fire_branch_event("NeogitBranchReset", { branch_name = current, resetting_to = to })
 end)
 
 M.delete_branch = operation("delete_branch", function()
@@ -251,6 +263,7 @@ M.delete_branch = operation("delete_branch", function()
     else
       notification.info(string.format("Deleted branch '%s'", branch_name))
     end
+    fire_branch_event("NeogitBranchDelete", { branch_name = branch_name })
   end
 end)
 

--- a/lua/neogit/popups/tag/actions.lua
+++ b/lua/neogit/popups/tag/actions.lua
@@ -7,6 +7,10 @@ local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 local input = require("neogit.lib.input")
 local notification = require("neogit.lib.notification")
 
+local function fire_tag_event(pattern, data)
+  vim.api.nvim_exec_autocmds("User", { pattern = pattern, modeline = false, data = data })
+end
+
 function M.create_tag(popup)
   local tag_input = input.get_user_input("Tag name: ")
   if not tag_input or tag_input == "" then
@@ -29,13 +33,16 @@ function M.create_tag(popup)
     table.insert(args, "--annotate")
   end
 
-  client.wrap(git.cli.tag.arg_list(utils.merge(args, { tag_input, selected })), {
+  local code = client.wrap(git.cli.tag.arg_list(utils.merge(args, { tag_input, selected })), {
     autocmd = "NeogitTagComplete",
     msg = {
       success = "Added tag " .. tag_input .. " on " .. selected,
       fail = "Failed to add tag " .. tag_input .. " on " .. selected,
     },
   })
+  if code == 0 then
+    fire_tag_event("NeogitTagCreate", { name = tag_input, ref = selected })
+  end
 end
 
 --- Create a release tag for `HEAD'.
@@ -55,6 +62,9 @@ function M.delete(_)
 
   if git.tag.delete(tags) then
     notification.info("Deleted tags: " .. table.concat(tags, ","))
+    for _, tag in pairs(tags) do
+      fire_tag_event("NeogitTagDelete", { name = tag })
+    end
   end
 end
 


### PR DESCRIPTION
This provides a working solution for my problem in #938. Let me explain:

With the current four events the user (me^^) can set up a vim autocmd which closes and reopens the Graph View. Not pretty, but does the job for me. However it's a bit cumbersome to being only limited to update the view on commit, push, pull & fetch. With these additional events the log view also does update on other commands:

![more-events](https://github.com/NeogitOrg/neogit/assets/31999281/c680f2c3-167b-4eb3-b45d-e0c4d7f8cef3)

This is my user config for auto-updating:

```lua
local group = vim.api.nvim_create_augroup("MyCustomNeogitEvents", { clear = true })
vim.api.nvim_create_autocmd("User", {
  pattern = {
    "NeogitCherryPick",
    "NeogitBranchCheckout",
    "NeogitBranchCreated",
    "NeogitBranchDelete",
    "NeogitBranchReset",
    "NeogitBranchRename",
    "NeogitRebase",
    "NeogitReset",
    "NeogitTagCreate",
    "NeogitTagDelete",
    "NeogitCommitComplete",
    "NeogitPushComplete",
    "NeogitPullComplete",
    "NeogitFetchComplete",
  },
  group = group,
  callback = function(event)
    print("Event: " .. vim.inspect(event.file))
    local buffername = vim.api.nvim_buf_get_name(event.buf)
    if buffername:match("NeogitLogView$") then
      vim.fn.feedkeys("q", "x") -- Close Log Graph
      require("neogit").open({ "log" })
      vim.fn.feedkeys("b", "x") -- Open log graph (branches) again    end
    end
  end,
})
```

If you want this example config could become part of some "Recipes" documentation or so...

---

FWIW, maybe other people might benefit from these events, that's why this PR =) 