### PR TITLE
Unconditionally disable switch when input is empty

### DIFF
--- a/lua/neogit/lib/popup/init.lua
+++ b/lua/neogit/lib/popup/init.lua
@@ -249,8 +249,10 @@ function M:toggle_switch(switch)
   if switch.user_input then
     if switch.enabled then
       local value = input.get_user_input(switch.cli_prefix .. switch.cli_base .. ": ")
-      if value then
+      if value ~= "" then
         switch.cli = switch.cli_base .. value
+      else
+        switch.enabled = false
       end
     else
       switch.cli = switch.cli_base


### PR DESCRIPTION
this can results in empty user input being passed to git cli where a non-empty string was needed.

regarding tests i haven't any tests related to toggle switches i would be like to guided on that.