### PR TITLE
Enhancement: Only show filtered file diffs from log view

### DIFF
--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -4,7 +4,6 @@ local ui = require("neogit.buffers.commit_view.ui")
 local git = require("neogit.lib.git")
 local config = require("neogit.config")
 local popups = require("neogit.popups")
-local notification = require("neogit.lib.notification")
 local status_maps = require("neogit.config").get_reversed_status_maps()
 
 local api = vim.api
@@ -40,13 +39,9 @@ local M = {
 
 ---Creates a new CommitViewBuffer
 ---@param commit_id string the id of the commit/tag
----@param notify boolean? Should show a notification or not
+---@param filter string[]? Filter diffs to filepaths in table
 ---@return CommitViewBuffer
-function M.new(commit_id, notify)
-  if notify then
-    notification.info("Parsing commit...")
-  end
-
+function M.new(commit_id, filter)
   local commit_info =
     git.log.parse(git.cli.show.format("fuller").args(commit_id).call_sync({ trim = false }).stdout)[1]
   commit_info.commit_arg = commit_id
@@ -59,8 +54,6 @@ function M.new(commit_id, notify)
     commit_signature = config.values.commit_view.verify_commit and git.log.verify_commit(commit_id) or {},
     buffer = nil,
   }
-
-  notification.delete_all()
 
   setmetatable(instance, { __index = M })
 

--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -44,13 +44,18 @@ local M = {
 function M.new(commit_id, filter)
   local commit_info =
     git.log.parse(git.cli.show.format("fuller").args(commit_id).call_sync({ trim = false }).stdout)[1]
+
   commit_info.commit_arg = commit_id
+
+  local commit_overview = parser.parse_commit_overview(
+    git.cli.show.stat.oneline.args(commit_id).call_sync().stdout
+  )
+
   local instance = {
     is_open = false,
+    item_filter = filter,
     commit_info = commit_info,
-    commit_overview = parser.parse_commit_overview(
-      git.cli.show.stat.oneline.args(commit_id).call_sync().stdout
-    ),
+    commit_overview = commit_overview,
     commit_signature = config.values.commit_view.verify_commit and git.log.verify_commit(commit_id) or {},
     buffer = nil,
   }
@@ -249,7 +254,7 @@ function M:open(kind)
       },
     },
     render = function()
-      return ui.CommitView(self.commit_info, self.commit_overview, self.commit_signature)
+      return ui.CommitView(self.commit_info, self.commit_overview, self.commit_signature, self.item_filter)
     end,
   }
 end

--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -47,9 +47,8 @@ function M.new(commit_id, filter)
 
   commit_info.commit_arg = commit_id
 
-  local commit_overview = parser.parse_commit_overview(
-    git.cli.show.stat.oneline.args(commit_id).call_sync().stdout
-  )
+  local commit_overview =
+    parser.parse_commit_overview(git.cli.show.stat.oneline.args(commit_id).call_sync().stdout)
 
   local instance = {
     is_open = false,

--- a/lua/neogit/buffers/commit_view/ui.lua
+++ b/lua/neogit/buffers/commit_view/ui.lua
@@ -46,7 +46,21 @@ function M.CommitHeader(info)
   }
 end
 
-function M.CommitView(info, overview, signature_block)
+function M.CommitView(info, overview, signature_block, item_filter)
+  if item_filter then
+    overview.files = util.filter_map(overview.files, function(file)
+      if vim.tbl_contains(item_filter, vim.trim(file.path)) then
+        return file
+      end
+    end)
+
+    info.diffs = util.filter_map(info.diffs, function(diff)
+      if vim.tbl_contains(item_filter, vim.trim(diff.file)) then
+        return diff
+      end
+    end)
+  end
+
   local hide_signature = vim.tbl_isempty(signature_block)
 
   return {

--- a/lua/neogit/buffers/log_view/init.lua
+++ b/lua/neogit/buffers/log_view/init.lua
@@ -9,15 +9,18 @@ local CommitViewBuffer = require("neogit.buffers.commit_view")
 ---@class LogViewBuffer
 ---@field commits CommitLogEntry[]
 ---@field internal_args table
+---@field files string[]
 local M = {}
 M.__index = M
 
 ---Opens a popup for selecting a commit
 ---@param commits CommitLogEntry[]|nil
 ---@param internal_args table|nil
+---@param files string[]|nil list of files to filter by
 ---@return LogViewBuffer
-function M.new(commits, internal_args)
+function M.new(commits, internal_args, files)
   local instance = {
+    files = files,
     commits = commits,
     internal_args = internal_args,
     buffer = nil,
@@ -128,7 +131,7 @@ function M:open()
           self:close()
         end,
         ["<enter>"] = function()
-          CommitViewBuffer.new(self.buffer.ui:get_commit_under_cursor()):open()
+          CommitViewBuffer.new(self.buffer.ui:get_commit_under_cursor(), self.files):open()
         end,
         ["<c-k>"] = function(buffer)
           local stack = self.buffer.ui:get_component_stack_under_cursor()

--- a/lua/neogit/popups/log/actions.lua
+++ b/lua/neogit/popups/log/actions.lua
@@ -25,40 +25,43 @@ end
 
 -- TODO: Handle when head is detached
 M.log_current = operation("log_current", function(popup)
-  LogViewBuffer.new(commits(popup, {}), popup:get_internal_arguments()):open()
+  LogViewBuffer.new(commits(popup, {}), popup:get_internal_arguments(), popup.state.env.files):open()
 end)
 
 function M.log_head(popup)
-  LogViewBuffer.new(commits(popup, { "HEAD" }), popup:get_internal_arguments()):open()
+  LogViewBuffer.new(commits(popup, { "HEAD" }), popup:get_internal_arguments(), popup.state.env.files):open()
 end
 
 function M.log_local_branches(popup)
   LogViewBuffer.new(
     commits(popup, { git.branch.is_detached() and "" or "HEAD", "--branches" }),
-    popup:get_internal_arguments()
+    popup:get_internal_arguments(),
+    popup.state.env.files
   ):open()
 end
 
 function M.log_other(popup)
   local branch = FuzzyFinderBuffer.new(git.branch.get_all_branches()):open_async()
   if branch then
-    LogViewBuffer.new(commits(popup, { branch }), popup:get_internal_arguments()):open()
+    LogViewBuffer.new(commits(popup, { branch }), popup:get_internal_arguments(), popup.state.env.files)
+      :open()
   end
 end
 
 function M.log_all_branches(popup)
   LogViewBuffer.new(
     commits(popup, { git.branch.is_detached() and "" or "HEAD", "--branches", "--remotes" }),
-    popup:get_internal_arguments()
+    popup:get_internal_arguments(),
+    popup.state.env.files
   ):open()
 end
 
 function M.log_all_references(popup)
   LogViewBuffer.new(
     commits(popup, { git.branch.is_detached() and "" or "HEAD", "--all" }),
-    popup:get_internal_arguments()
-  )
-    :open()
+    popup:get_internal_arguments(),
+    popup.state.env.files
+  ):open()
 end
 
 function M.reflog_current(popup)

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -1285,7 +1285,7 @@ local cmd_func_map = function()
             if M.commit_view and M.commit_view.is_open then
               M.commit_view:close()
             end
-            M.commit_view = CommitView.new(item.name:match("(.-):? "), true)
+            M.commit_view = CommitView.new(item.name:match("(.-):? "))
             M.commit_view:open()
           end
         end
@@ -1298,7 +1298,7 @@ local cmd_func_map = function()
           if M.commit_view and M.commit_view.is_open then
             M.commit_view:close()
           end
-          M.commit_view = CommitView.new(ref, true)
+          M.commit_view = CommitView.new(ref)
           M.commit_view:open()
         end
       end


### PR DESCRIPTION
When you filter by filename in the log view, this filter should be applied to the commit buffer if it's opened, and only show diffs for those files.

Closes #1014 