### PR TITLE
Fix close abort

### DIFF
--- a/lua/neogit/buffers/commit_editor/init.lua
+++ b/lua/neogit/buffers/commit_editor/init.lua
@@ -84,10 +84,11 @@ function M:open()
     mappings = {
       n = {
         [mapping["Close"]] = function(buffer)
-          if buffer:get_option("modified") and input.get_confirmation("Save changes?") then
-            buffer:write()
+          if buffer:get_option("modified") and not input.get_confirmation("Save changes?") then
+            aborted = true
           end
 
+          buffer:write()
           buffer:close(true)
         end,
         [mapping["Submit"]] = function(buffer)


### PR DESCRIPTION
Fixes #439 

Current issue repro in a neogit status buffer:
- <kbd>ca</kbd> in the status buffer to amend to the last commit.
- Change something in the commit message - don't save the buffer.
- <kbd>q</kbd> to close, a confirmation dialog starts. Hit <kbd>n</kbd>o in the saves changes confirmation dialog to not confirm the changes.
- The commit is made anyway / See the commit sha changing.

Ref.: https://github.com/NeogitOrg/neogit/pull/441#issuecomment-1858869791

With the changes in the PR the commit is not being made when not confirming the changes.

The changes are based on the `abort` implementation:
https://github.com/NeogitOrg/neogit/blob/a6a7ec026bd66fd196565a06bc6353b01327d09a/lua/neogit/buffers/commit_editor/init.lua#L97-L102

