### PR TITLE
Fixed commit SHA check preventing line actions in rebase editor

### DIFF
--- a/lua/neogit/buffers/rebase_editor/init.lua
+++ b/lua/neogit/buffers/rebase_editor/init.lua
@@ -21,7 +21,7 @@ local function line_action(action)
       return
     end
 
-    if line[2] and line[2]:match("%x%x%x%x%x%x%x%x%x%x") and line[1] ~= "Rebase" then
+    if line[2] and line[2]:match("%x%x%x%x%x%x%x%x") and line[1] ~= "Rebase" then
       line[1] = action
       vim.api.nvim_set_current_line(table.concat(line, " "))
       buffer:write()


### PR DESCRIPTION
Hey there !

The rebase editor actions stopped working recently and I was about to open an issue but the fix was really straightforward so I figured it would be even quicker to open a pull request.

In the rebase editor, there is a check trying to match a commit SHA of length 10 instead of 8. Looking at other parts of the code base it doesn't look intentional.

This was preventing most rebase editor actions from modifying the current line, at least on my repository.

Thanks for the awesome plugin by the way, I started using it recently and that's a really nice workflow !