### PR TITLE
Fix typos

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -557,7 +557,7 @@ Actions:                                           *neogit_branch_popup_actions*
   • Checkout branch/revision                        *neogit_branch_checkout_rev*
     Changes HEAD to point to the selected branch/revision. If a local branch
     is selected, that will be checked out. Otherwise HEAD will become
-    detatched. Any ref under the cursor or selected will be available to
+    detached. Any ref under the cursor or selected will be available to
     checkout.
 
   • Checkout local branch                         *neogit_branch_checkout_local*
@@ -600,7 +600,7 @@ Actions:                                           *neogit_branch_popup_actions*
 
   • Create new spin-out                                 *neogit_branch_spin_out*
     Like |neogit_branch_spin_off|, but doesn't change HEAD. However, if the
-    index has uncomitted changes, will behave exactly the same as spin_off.
+    index has uncommitted changes, will behave exactly the same as spin_off.
 
   • Create new worktree                          *neogit_branch_create_worktree*
     (Not yet implemented)
@@ -797,7 +797,7 @@ Arguments:                                            *neogit_commit_popup_args*
     and --gpg-sign
 
   • --reset-author
-    When used while ammending or when committing after a conflicting
+    When used while amending or when committing after a conflicting
     cherry-pick, declare that the authorship of the resulting commit now
     belongs to the committer. This also renews the author timestamp.
 

--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -14,8 +14,8 @@ local api = vim.api
 ---@field author_name string
 ---@field author_date string
 ---@field commit_arg string The commit argument passed to `git show`
----@field commiter_email string
----@field commiter_date string
+---@field committer_email string
+---@field committer_date string
 ---@field description table
 
 ---@class CommitOverview

--- a/lua/neogit/buffers/editor/init.lua
+++ b/lua/neogit/buffers/editor/init.lua
@@ -37,7 +37,7 @@ function M.new(filename, on_unload)
 end
 
 function M:open(kind)
-  assert(kind, "Editor must speficy a kind")
+  assert(kind, "Editor must specify a kind")
 
   local mapping = config.get_reversed_commit_editor_maps()
   local aborted = false

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -142,7 +142,7 @@ end
 ---@field kind? WindowKind The default type of window neogit should open in
 ---@field disable_line_numbers? boolean Whether to disable line numbers
 ---@field console_timeout? integer Time in milliseconds after a console is created for long running commands
----@field auto_show_console? boolean Automatically show the console if a command takes longer than console_timout
+---@field auto_show_console? boolean Automatically show the console if a command takes longer than console_timeout
 ---@field status? { recent_commit_count: integer } Status buffer options
 ---@field commit_editor? NeogitConfigPopup Commit editor options
 ---@field commit_select_view? NeogitConfigPopup Commit select view options

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -14,10 +14,10 @@ local commit_header_pat = "([| ]*)(%*?)([| ]*)commit (%w+)"
 ---@field graph string the graph string
 ---@field author_name string the name of the author
 ---@field author_email string the email of the author
----@field author_date string when the author commited
+---@field author_date string when the author committed
 ---@field committer_name string the name of the committer
 ---@field committer_email string the email of the committer
----@field committer_date string when the committer commited
+---@field committer_date string when the committer committed
 ---@field description string a list of lines
 ---@field commit_arg string the passed argument of the git command
 ---@field diffs any[]

--- a/lua/neogit/lib/popup/builder.lua
+++ b/lua/neogit/lib/popup/builder.lua
@@ -82,7 +82,7 @@ end
 ---@param opts table|nil A table of options for the switch
 ---@param opts.enabled boolean Controls if the switch should default to 'on' state
 ---@param opts.internal boolean Whether the switch is internal to neogit or should be included in the cli command.
---                              If `true` we don't include it in the cli comand.
+--                              If `true` we don't include it in the cli command.
 ---@param opts.incompatible table A table of strings that represent other cli flags that this one cannot be used with
 ---@param opts.key_prefix string Allows overwriting the default '-' to toggle switch
 ---@param opts.cli_prefix string Allows overwriting the default '--' thats used to create the cli flag. Sometimes you may want

--- a/lua/neogit/popups/ignore/init.lua
+++ b/lua/neogit/popups/ignore/init.lua
@@ -5,7 +5,7 @@ local popup = require("neogit.lib.popup")
 local M = {}
 
 ---@class IgnoreEnv
----@field files string[] Abolute paths
+---@field files string[] Absolute paths
 function M.create(env)
   local excludesFile = require("neogit.lib.git.config").get_global("core.excludesfile")
 

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -211,7 +211,7 @@ end
 
 function Process.defer_show_preview_buffers()
   hide_console = false
-  --- Start the timers again, making all proceses show the log buffer on a long
+  --- Start the timers again, making all processes show the log buffer on a long
   --- running command
   for _, v in pairs(processes) do
     v:start_timer()
@@ -346,7 +346,7 @@ function Process:spawn(cb)
       end
 
       local message = string.format(
-        "%s:\n\n%s\n\nAn error occured.",
+        "%s:\n\n%s\n\nAn error occurred.",
         mask_command(table.concat(self.cmd, " ")),
         table.concat(output, "\n")
       )

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,7 +71,7 @@ describe("validating a string variable", function ()
   end)
 
   it("should have content 'Hello World!'", function()
-     assert.are.same("Hello World!", our_varible)
+     assert.are.same("Hello World!", our_variable)
   )
 end)
 ```

--- a/tests/specs/neogit/docs_spec.lua
+++ b/tests/specs/neogit/docs_spec.lua
@@ -30,7 +30,7 @@ describe("docs", function()
 
     for _, ref in ipairs(refs) do
       if not tags[ref] then
-        vim.print("Undefined tag refrenced! " .. ref)
+        vim.print("Undefined tag referenced! " .. ref)
       end
 
       assert.True(tags[ref])

--- a/tests/specs/neogit/popups/branch_spec.lua
+++ b/tests/specs/neogit/popups/branch_spec.lua
@@ -125,7 +125,7 @@ describe("branch popup", function()
       "can delete a local branch with unmerged commits",
       in_prepared_repo(function()
         FuzzyFinderBuffer.value = "second-branch"
-        input.confimed = true
+        input.confirmed = true
 
         util.system([[
           git switch second-branch


### PR DESCRIPTION
Hi, 👋.

I am very glad to feel at home with this project after 7 years in Emacs. However, I have come across several typos in this repository, thanks to [crate-ci/typos](https://github.com/crate-ci/typos). You can run the typos check locally using the CLI app and in CI using its GitHub action.

I am ready with a PR to set up the `typos` CI if you are okay with it.
