### PR TITLE
Use the Selene binary instead of building from source

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,26 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get latest selene version
-        id: selene-version
-        run: |
-          echo "SELENE_VERSION=$(curl -s -L0 https://crates.io/api/v1/crates/selene  | jq -r '.crate.max_stable_version')" >> $GITHUB_ENV
+      - uses: Swatinem/rust-cache@v2
 
-      - name: Restore Cached Selene
-        id: cache-selene-restore
-        uses: actions/cache@v3
+      - uses: taiki-e/install-action@v2
         with:
-          key: ${{ runner.os }}-selene-${{ env.SELENE_VERSION }}
-          path: ~/.cargo/bin/selene
-
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        if: ${{ steps.cache-selene-restore.outputs.cache-hit != 'true' }}
-        with:
-          toolchain: stable
-
-      - name: Install Selene
-        if: ${{ steps.cache-selene-restore.outputs.cache-hit != 'true' }}
-        run: cargo install selene --force
+          tool: selene
 
       - name: Run Selene
         run: make lint


### PR DESCRIPTION
The `taiki-e/install-action` action pulls the target binary and resorts to building from source if not found. However, Selene is compatible with `cargo-binsall`, eliminating the need for source building.

The `Swatinem/rust-cache` action inherently caches `~/.cargo` directories, including the location where Selene is stored.