### PR TITLE
Add `typos` linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,9 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: selene
+          tool: selene,typos-cli
 
-      - name: Run Selene
+      - name: Run linters
         run: make lint
 
   stylua:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# `enew` is a valid nvim command
+enew = "enew"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ test:
 
 lint:
 	selene --config selene/config.toml lua
+	typos
 
 lint-short:
 	selene --config selene/config.toml --display-style Quiet lua

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -1063,7 +1063,7 @@ Arguments:                                              *neogit_push_popup_args*
     (tracking) reference.
 
   • --no-verify
-    Skips runing any pre-push git hooks. By default, all hooks are run.
+    Skips running any pre-push git hooks. By default, all hooks are run.
 
   • --dry-run
     Do everything except actually send the updates.


### PR DESCRIPTION
We have identified numerous typos in the past. Hopefully, incorporating `typos` into our linter tools will assist us in minimizing such errors.