### PR TITLE
Add Next/Previous message to editor

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -56,6 +56,7 @@ CONTENTS                                                       *neogit_contents*
 
     7. Buffers                                                 |neogit_buffers|
        • Status                                          |neogit_status_buffer|
+       • Editor                                          |neogit_editor_buffer|
        • Log                                                |neogit_log_buffer|
        • Reflog                                          |neogit_reflog_buffer|
        • Commit                                          |neogit_commit_buffer|
@@ -1428,9 +1429,11 @@ Actions:                                         *neogit_worktree_popup_actions*
 7. Buffers                                                      *neogit_buffers*
 
 • Status                                                  |neogit_status_buffer|
+• Editor                                                  |neogit_editor_buffer|
 • Log                                                        |neogit_log_buffer|
 • Reflog                                                  |neogit_reflog_buffer|
 • Commit                                                  |neogit_commit_buffer|
+• Rebase Todo                                        |neogit_rebase_todo_buffer|
 
 ==============================================================================
 Status Buffer                                             *neogit_status_buffer*
@@ -1440,6 +1443,47 @@ Untracked Files                                 *neogit_status_buffer_untracked*
   Neogit respects status.showUntrackedFiles. It can be set to "no" to hide
   untracked files entirely, "normal" to show files and directories (default),
   or "all" to show all files in all directories.
+
+==============================================================================
+Editor Buffer                                             *neogit_editor_buffer*
+
+Commands:                                               *neogit_editor_commands*
+  • Close                                                  *neogit_editor_close*
+    Default key: `q`
+
+    Closes the editor buffer. If there are unsaved changes, user will be
+    prompted to save them. Discarding the changes will abort.
+
+  • Submit                                                *neogit_editor_submit*
+    Default key: `<c-c><c-c>`
+
+    Writes and closes the editor.
+
+  • Abort                                                  *neogit_editor_abort*
+    Default key: `<c-c><c-k>`
+
+    Closes the editor buffer, discarding any changes that might have been
+    written.
+
+  • PrevMessage                                     *neogit_editor_prev_message*
+    Default key: `<m-p>`
+
+    Replaces the current commit message with the previously used one, via
+    reflog. Messages that have been discarded via reset will be included as
+    well. Any changes a user makes to a message will be stored while the
+    editor is open.
+
+  • NextMessage                                     *neogit_editor_next_message*
+    Default key: `<m-n>`
+
+    Replaces the current commit message with the next used one, via
+    reflog. Same semantics as |neogit_editor_prev_message| apply.
+
+  • ResetMessage                                   *neogit_editor_reset_message*
+    Default key: `<m-r>`
+
+    If a user has changed a message that was found via reflog, reset it to how
+    it appeared in reflog.
 
 ==============================================================================
 Log Buffer                                                   *neogit_log_buffer*

--- a/lua/neogit/buffers/editor/init.lua
+++ b/lua/neogit/buffers/editor/init.lua
@@ -176,7 +176,7 @@ function M:open(kind)
           local message = current_message(buffer)
           buffer:set_lines(0, #message, false, reflog_message(message_index))
           buffer:move_cursor(1)
-        end
+        end,
       },
     },
   }

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -114,7 +114,7 @@ end
 
 ---@alias NeogitConfigMappingsRebaseEditor "Pick" | "Reword" | "Edit" | "Squash" | "Fixup" | "Execute" | "Drop" | "Break" | "MoveUp" | "MoveDown" | "Close" | "OpenCommit" | "Submit" | "Abort" | false | fun()
 ---
----@alias NeogitConfigMappingsCommitEditor "Close" | "Submit" | "Abort" | false | fun()
+---@alias NeogitConfigMappingsCommitEditor "Close" | "Submit" | "Abort" | "PrevMessage" | "NextMessage" | false | fun()
 
 ---@class NeogitConfigMappings Consult the config file or documentation for values
 ---@field finder? { [string]: NeogitConfigMappingsFinder } A dictionary that uses finder commands to set multiple keybinds
@@ -301,6 +301,8 @@ function M.get_default_values()
         ["q"] = "Close",
         ["<c-c><c-c>"] = "Submit",
         ["<c-c><c-k>"] = "Abort",
+        ["<m-p>"] = "PrevMessage",
+        ["<m-n>"] = "NextMessage",
       },
       rebase_editor = {
         ["p"] = "Pick",

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -114,7 +114,7 @@ end
 
 ---@alias NeogitConfigMappingsRebaseEditor "Pick" | "Reword" | "Edit" | "Squash" | "Fixup" | "Execute" | "Drop" | "Break" | "MoveUp" | "MoveDown" | "Close" | "OpenCommit" | "Submit" | "Abort" | false | fun()
 ---
----@alias NeogitConfigMappingsCommitEditor "Close" | "Submit" | "Abort" | "PrevMessage" | "NextMessage" | false | fun()
+---@alias NeogitConfigMappingsCommitEditor "Close" | "Submit" | "Abort" | "PrevMessage" | "ResetMessage" | "NextMessage" | false | fun()
 
 ---@class NeogitConfigMappings Consult the config file or documentation for values
 ---@field finder? { [string]: NeogitConfigMappingsFinder } A dictionary that uses finder commands to set multiple keybinds
@@ -303,6 +303,7 @@ function M.get_default_values()
         ["<c-c><c-k>"] = "Abort",
         ["<m-p>"] = "PrevMessage",
         ["<m-n>"] = "NextMessage",
+        ["<m-r>"] = "ResetMessage",
       },
       rebase_editor = {
         ["p"] = "Pick",

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -81,7 +81,7 @@ function Buffer:write()
 end
 
 function Buffer:get_lines(first, last, strict)
-  return api.nvim_buf_get_lines(self.handle, first, last, strict)
+  return api.nvim_buf_get_lines(self.handle, first, last, strict or false)
 end
 
 function Buffer:get_line(line)

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -148,13 +148,7 @@ function Buffer:set_text(first_line, last_line, first_col, last_col, lines)
 end
 
 function Buffer:move_cursor(line)
-  if line < 0 then
-    self:focus()
-    vim.cmd("norm! G")
-  else
-    self:focus()
-    vim.cmd("norm! " .. line .. "G")
-  end
+  api.nvim_win_set_cursor(0, { line, 0 })
 end
 
 function Buffer:close(force)

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -535,4 +535,12 @@ M.branch_info = util.memoize(function(ref, remotes)
   return result
 end)
 
+function M.reflog_message(skip)
+  return cli.log
+    .format("%B")
+    .max_count(1)
+    .args("--reflog", "--no-merges", "--skip=" .. tostring(skip))
+    .call_sync({ ignore_error = true }).stdout
+end
+
 return M

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -193,20 +193,20 @@ function M.str_min_width(str, len, sep)
   return str .. string.rep(sep or " ", len - length)
 end
 
--- function M.slice(tbl, s, e)
---   local pos, new = 1, {}
---
---   if e == nil then
---     e = #tbl
---   end
---
---   for i = s, e do
---     new[pos] = tbl[i]
---     pos = pos + 1
---   end
---
---   return new
--- end
+function M.slice(tbl, s, e)
+  local pos, new = 1, {}
+
+  if e == nil then
+    e = #tbl
+  end
+
+  for i = s, e do
+    new[pos] = tbl[i]
+    pos = pos + 1
+  end
+
+  return new
+end
 
 -- function M.str_count(str, target)
 --   local count = 0


### PR DESCRIPTION
Adds `NextMessage`, `PrevMessage`, and `ResetMessage` commands to editor buffer. Probably only works nicely for commit messages. Will dig up messages from reflog

todo: docs