### PR TITLE
Hide rev-parse --verify from history

### DIFF
--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -97,11 +97,11 @@ end
 ---@param branch string
 ---@return boolean
 function M.exists(branch)
-  local check = cli["rev-parse"].verify
+  local result = cli["rev-parse"].verify.quiet
     .args(string.format("refs/heads/%s", branch))
-    .call_sync({ ignore_error = true }).stdout[1]
+    .call_sync({ hidden = true, ignore_error = true })
 
-  return check ~= nil
+  return result.code == 0
 end
 
 ---Determine if a branch name ("origin/master", "fix/bug-1000", etc)

--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -99,7 +99,7 @@ end
 function M.exists(branch)
   local result = cli["rev-parse"].verify.quiet
     .args(string.format("refs/heads/%s", branch))
-    .call_sync({ hidden = true, ignore_error = true })
+    .call_sync { hidden = true, ignore_error = true }
 
   return result.code == 0
 end

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -508,6 +508,7 @@ local configurations = {
   ["rev-parse"] = config {
     flags = {
       verify = "--verify",
+      quiet = "--quiet",
       short = "--short",
       revs_only = "--revs-only",
       no_revs = "--no-revs",


### PR DESCRIPTION
Make sure this doesn't show up in cmd history - it's ok to fail, that just means the thing doesn't exist