### PR TITLE
Use for-the-badge style for Dotfyle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   [![Neovim](https://img.shields.io/badge/Neovim%200.9+-green.svg?style=for-the-badge&logo=neovim)](https://neovim.io)
   [![MIT](https://img.shields.io/badge/MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
   <a href="https://dotfyle.com/plugins/NeogitOrg/neogit">
-    <img src="https://dotfyle.com/plugins/NeogitOrg/neogit/shield" />
+    <img src="https://dotfyle.com/plugins/NeogitOrg/neogit/shield?style=for-the-badge" />
   </a>
 </div>
 


### PR DESCRIPTION
Thanks for adding the Dotfyle badge to the repo! Noticed that the dotfyle badge had a different style, so changed it. This styling aligns with the other badges in the Readme.