### PR TITLE
Fix: Json parsing

### DIFF
--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -184,7 +184,14 @@ M.CommitEntry = Component.new(function(commit, args)
       row(graph),
       col(
         flat_map({ commit.subject, commit.body }, function(line)
-          local lines = map(util.str_wrap(line, vim.o.columns * 0.6), function(l)
+          local lines = vim.split(line, "\\n")
+
+          -- TODO: More correctly handle newlines/wrapping in messages
+          -- lines = util.flat_map(lines, function(line)
+          --   return util.str_wrap(line, vim.o.columns * 0.6)
+          -- end)
+
+          lines = map(lines, function(l)
             return row(util.merge(graph, { text(" "), text(l) }))
           end)
 

--- a/lua/neogit/lib/json.lua
+++ b/lua/neogit/lib/json.lua
@@ -69,7 +69,7 @@ end
 ---@param tbl table Key/value pairs to encode as json
 ---@return string
 function M.encode(tbl)
-  return string.format("%s,", vim.json.encode(tbl))
+  return string.format([[%s,]], vim.fn.json_encode(tbl):gsub(" ", ""))
 end
 
 return M

--- a/lua/neogit/lib/json.lua
+++ b/lua/neogit/lib/json.lua
@@ -25,20 +25,18 @@ local function escape_field(json_str, field)
   return json_str
 end
 
-local function raise_error(result, input)
+local function error_msg(result, input)
   local msg = vim.split(result, " ")
   local char_index = tonumber(msg[#msg])
 
-  error(
-    "Failed to parse log json!: "
-      .. result
-      .. "\n"
-      .. input:sub(char_index - 30, char_index - 1)
-      .. "<"
-      .. input:sub(char_index, char_index)
-      .. ">"
-      .. input:sub(char_index + 1, char_index + 30)
-  )
+  return "Failed to parse log json!: "
+    .. result
+    .. "\n"
+    .. input:sub(char_index - 30, char_index - 1)
+    .. "<"
+    .. input:sub(char_index, char_index)
+    .. ">"
+    .. input:sub(char_index + 1, char_index + 30)
 end
 
 ---Decode a list of json formatted lines into a lua table
@@ -46,6 +44,10 @@ end
 ---@param opts? table
 ---@return table
 function M.decode(lines, opts)
+  if not lines[1] then
+    return {}
+  end
+
   opts = opts or {}
 
   local json_array = array_wrap(lines)
@@ -58,7 +60,11 @@ function M.decode(lines, opts)
 
   local ok, result = pcall(vim.json.decode, json_array, { luanil = { object = true, array = true } })
   if not ok then
-    raise_error(result, json_array)
+    error(error_msg(result, json_array))
+  end
+
+  if not result then
+    error("Json failed to parse!")
   end
 
   return result

--- a/lua/neogit/lib/json.lua
+++ b/lua/neogit/lib/json.lua
@@ -16,7 +16,7 @@ end
 ---@param json_str string unparsed json
 ---@param field string The json key to escape the body for
 local function escape_field(json_str, field)
-  local pattern = ([[("%s":")(.-)(",")]]):format(field)
+  local pattern = ([[("%s":")(.-)(","%%l)]]):format(field)
 
   json_str, _ = json_str:gsub(pattern, function(before, value, after)
     return table.concat({ before, vim.fn.escape(value, [[\"]]), after }, "")
@@ -66,10 +66,13 @@ end
 
 ---Convert a lua table to json string. Trailing comma is added because the expectation
 ---is to use json.decode from this same module to parse the result.
+---The 'null' key is because the escape_field function won't match the _last_ field in an object,
+---so by adding a null field, we can guarantee that the last _real_ field will be escaped.
 ---@param tbl table Key/value pairs to encode as json
 ---@return string
 function M.encode(tbl)
-  return string.format([[%s,]], vim.fn.json_encode(tbl):gsub(" ", ""))
+  local json, _ = string.format([[%s,]], vim.json.encode(tbl)):gsub([[}]], [[,"null":null}]])
+  return json
 end
 
 return M

--- a/tests/specs/neogit/lib/json_spec.lua
+++ b/tests/specs/neogit/lib/json_spec.lua
@@ -3,7 +3,7 @@ local subject = require("neogit.lib.json")
 describe("lib.json", function()
   describe("#encode", function()
     it("turns a lua table into json with a trailing comma", function()
-      assert.are.same('{"foo":"bar"},', subject.encode { foo = "bar" })
+      assert.are.same('{"foo":"bar","null":null},', subject.encode { foo = "bar" })
     end)
   end)
 


### PR DESCRIPTION
Turns out `vim.json.encode` doesn't produce a deterministic ordering across sessions. Add a final `"null"` field so our escape function will be able to pattern match properly

Fixes #1107 