### PR TITLE
Allow instantly rebasing what would otherwise require the editor

### DIFF
--- a/lua/neogit/lib/git/rebase.lua
+++ b/lua/neogit/lib/git/rebase.lua
@@ -16,6 +16,23 @@ local function rebase_command(cmd)
   return cmd.env(client.get_envs_git_editor()).show_popup(true):in_pty(true).call { verbose = true }
 end
 
+---Instant rebase. This is a way to rebase without using the interactive editor
+---@param commit string
+---@param args string[] list of arguments to pass to git rebase
+---@return ProcessResult
+function M.instantly(commit, args)
+  local result =
+    cli.rebase.env({ GIT_SEQUENCE_EDITOR = ":" }).interactive.arg_list(args).commit(commit).call()
+
+  if result.code ~= 0 then
+    fire_rebase_event { commit = commit, status = "failed" }
+  else
+    fire_rebase_event { commit = commit, status = "ok" }
+  end
+
+  return result
+end
+
 function M.rebase_interactive(commit, args)
   if vim.tbl_contains(args, "--root") then
     commit = ""

--- a/lua/neogit/popups/commit/actions.lua
+++ b/lua/neogit/popups/commit/actions.lua
@@ -99,7 +99,7 @@ local function commit_special(popup, method, opts)
 
   if opts.rebase then
     a.util.scheduler()
-    git.rebase.rebase_interactive(commit .. "~1", { "--autosquash", "--autostash", "--keep-empty" })
+    git.rebase.instantly(commit .. "~1", { "--autosquash", "--autostash", "--keep-empty" })
   end
 end
 


### PR DESCRIPTION
Use technique from https://peterevans.dev/posts/how-to-rewrite-git-commit-messages-non-interactively/