### PR TITLE
fix: typo in the kind type

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -67,7 +67,7 @@ end
 ---@alias WindowKind
 ---|"split" Open in a split
 ---| "vsplit" Open in a vertical split
----| "float" Open in a floating window
+---| "floating" Open in a floating window
 ---| "tab" Open in a new tab
 
 ---@class NeogitCommitBufferConfig Commit buffer options


### PR DESCRIPTION
I ran into this typo in the type annotations while changing my config. (Alternatively, if the string is supposed to be "float", a change elsewhere in the code needs to be made.)