### PR TITLE
FIX: Proper quiting of `stash rename`

### DIFF
--- a/lua/neogit/lib/git/stash.lua
+++ b/lua/neogit/lib/git/stash.lua
@@ -111,6 +111,10 @@ end
 
 function M.rename(stash)
   local message = input.get_user_input("New name")
+  if message == nil then
+    -- User pressed ESC or entered empty message, dont drop stash
+    return
+  end
   local oid = rev_parse.abbreviate_commit(stash)
   cli.stash.drop.args(stash).call()
   cli.stash.store.message(message).args(oid).call()

--- a/tests/specs/neogit/popups/stash_spec.lua
+++ b/tests/specs/neogit/popups/stash_spec.lua
@@ -50,4 +50,17 @@ describe("stash popup", function()
       assert.are.same({ "stash@{0}: Foobar" }, git.stash.list())
     end)
   )
+
+  it(
+    "rename stash doesn't drop stash if user presses ESC on message prompt",
+    in_prepared_repo(function()
+      util.system("git stash")
+      FuzzyFinderBuffer.value = { "stash@{0}" }
+
+      act("Zm<esc>")
+      operations.wait("stash_rename")
+
+      assert.are.same(1, #git.stash.list())
+    end)
+  )
 end)


### PR DESCRIPTION
Sorry just noticed a little bug, with the `stash rename`: When input is `nil` (e.g. when user quit the message prompt with ESC) then the stash is dropped =S