### PR TITLE
Fix #1047

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -1,6 +1,7 @@
 local logger = require("neogit.logger")
 local process = require("neogit.process")
 local util = require("neogit.lib.util")
+local Path = require("plenary.path")
 
 local function config(setup)
   setup = setup or {}
@@ -572,7 +573,8 @@ local function git_root_of_cwd()
     :spawn_blocking()
 
   if process ~= nil and process.code == 0 then
-    return process.stdout[1]
+    local out = process.stdout[1]
+    return Path:new(out):absolute()
   else
     return ""
   end


### PR DESCRIPTION
_Cause of bug_:
Command used to get initial repository directory returns unix path seperators on windows.
This confuses the `plenary.path` module.

_Fix_:
Use `plenary.path` to convert the output of the git command to windows style path