### PR TITLE
Fix string pattern for type-2 `git status -z` entries

### DIFF
--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -40,7 +40,7 @@ local tag_pattern = "(.-)%-([0-9]+)%-g%x+$"
 local match_kind = "(.) (.+)"
 local match_u = "(..) (....) (%d+) (%d+) (%d+) (%d+) (%w+) (%w+) (%w+) (.+)"
 local match_1 = "(.)(.) (....) (%d+) (%d+) (%d+) (%w+) (%w+) (.+)"
-local match_2 = "(.)(.) (....) (%d+) (%d+) (%d+) (%w+) (%w+) (%a%d+) ([^\t]+)\t?(.+)"
+local match_2 = "(.)(.) (....) (%d+) (%d+) (%d+) (%w+) (%w+) (%a%d+) (.+)%z(.+)"
 
 local function update_status(state)
   local git = require("neogit.lib.git")


### PR DESCRIPTION
Closes #1157.

Tested with the example from https://github.com/NeogitOrg/neogit/issues/1157#issuecomment-1926767545:

```lua
-- NEW!
local match_2 = "(.)(.) (....) (%d+) (%d+) (%d+) (%w+) (%w+) (%a%d+) (.+)%z(.+)" 

local rest = "R. N... 100644 100644 100644 ac01e6941fe11104afee78fa73ad77f9707d169b ac01e6941fe11104afee78fa73ad77f9707d169b R100 lua/plugins/lsp/rust-analyzer.lua\0lua/plugins/lsp/rust_analyzer.lua"
local mode_staged, mode_unstaged, _, _, _, _, _, _, _, name, orig_name = rest:match(match_2)

print(orig_name) -- lua/plugins/lsp/rust_analyzer.lua
print(name)      -- lua/plugins/lsp/rust-analyzer.lua
```