### PR TITLE
Fix: Renamed files not appearing properly in status buffer

### DIFF
--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -14,6 +14,18 @@ function M.map(tbl, f)
 end
 
 ---@generic T: any
+---@param tbl T[]
+---@param f fun(v: T, c: table)
+---@return table
+function M.collect(tbl, f)
+  local t = {}
+  for _, v in pairs(tbl) do
+    f(v, t)
+  end
+  return t
+end
+
+---@generic T: any
 ---@param tbl T[][]
 ---@return T[]
 --- Flattens one level of lists

--- a/tests/specs/neogit/status_spec.lua
+++ b/tests/specs/neogit/status_spec.lua
@@ -23,6 +23,27 @@ local function find(text)
 end
 
 describe("status buffer", function()
+  describe("renamed files", function()
+    it(
+      "correctly tracks renames",
+      in_prepared_repo(function()
+        harness.exec { "touch", "testfile" }
+        harness.exec { "echo", "test file content", ">testfile" }
+        harness.exec { "git", "add", "testfile" }
+        harness.exec { "git", "commit", "-m", "'added testfile'" }
+        harness.exec { "mv", "testfile", "renamed-testfile" }
+        harness.exec { "git", "add", "testfile" }
+        harness.exec { "git", "add", "renamed-testfile" }
+
+        a.util.block_on(status.reset)
+        a.util.block_on(status.refresh)
+
+        local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
+        assert.True(vim.tbl_contains(lines, "Renamed testfile -> renamed-testfile"))
+      end)
+    )
+  end)
+
   describe("staging files - s", function()
     it(
       "Handles non-english filenames correctly",


### PR DESCRIPTION
Fix: Rebuild lines that have been "split" incorrectly when a \0 character has been replaced by a \n. This fixes renamed files not being listed properly in the status buffer.

Successor to: https://github.com/NeogitOrg/neogit/pull/1165