### PR TITLE
 Fix: graph invalid UTF-8 codepoint

### DIFF
--- a/lua/neogit/lib/graph.lua
+++ b/lua/neogit/lib/graph.lua
@@ -36,7 +36,7 @@ local missing_parent_empty_str  = "  "
 -- See also: 
 -- https://github.com/gijit/gi/blob/7052cfb07ca8b52afaa6c2a3deee53952784bd5d/pkg/utf8/utf8.lua#L80C1-L81C47
 --
-function utf8_iter(s)
+local function utf8_iter(s)
   local i = 1
   return function()
     local b = string.byte(s, i)


### PR DESCRIPTION
This PR fixes a scenario where UTF-8 codepoints passed to gsub would be swapped out with their Unicode replacement.

#### before:
![image](https://github.com/NeogitOrg/neogit/assets/91024200/1bae72f8-d97f-4c63-b633-dc0f7e421160)


#### after:
![image](https://github.com/NeogitOrg/neogit/assets/91024200/49d106b8-c793-4762-a4a7-f289bae20928)
