### PR TITLE
Fixed unwanted trim for file from diffview

### DIFF
--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -92,9 +92,9 @@ local function get_local_diff_view(section_name, item_name, opts)
           table.insert(args, "HEAD")
         end
 
-        return neogit.cli.show.file(unpack(args)).call_sync().stdout
+        return neogit.cli.show.file(unpack(args)).call_sync({ trim = false }).stdout
       elseif kind == "working" then
-        local fdata = neogit.cli.show.file(path).call_sync().stdout
+        local fdata = neogit.cli.show.file(path).call_sync({ trim = false }).stdout
         return side == "left" and fdata
       end
     end,


### PR DESCRIPTION
call_sync method trims output by default. DiffView needs to read file as it is.
issue:'Diff view shows a lot of noise caused by blank lines #1108'