### PR TITLE
Bugfix: default telescope sorter with directory picker

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -31,7 +31,14 @@ local function telescope_mappings(on_select, allow_multi, refocus_status)
         table.insert(selection, item[1])
       end
     elseif action_state.get_selected_entry() ~= nil then
-      table.insert(selection, action_state.get_selected_entry()[1])
+      local entry = action_state.get_selected_entry()[1]
+      local prompt = picker:_get_prompt()
+
+      if entry == ".." and #prompt > 0 then
+        table.insert(selection, prompt)
+      else
+        table.insert(selection, entry)
+      end
     else
       table.insert(selection, picker:_get_prompt())
     end


### PR DESCRIPTION
When choosing a directory with the default telescope sorter, do not select ".." if it's highlighted while there's something else written in the prompt.

This still respects if the user types "..", since thats used instead of the selection.

closes #1180