### PR TITLE
Discard Conflicted Files

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -214,6 +214,8 @@ local configurations = {
     flags = {
       _track = "--track",
       detach = "--detach",
+      ours = "--ours",
+      theirs = "--theirs",
     },
     aliases = {
       track = function(tbl)
@@ -244,6 +246,11 @@ local configurations = {
       new_branch_with_start_point = function(tbl)
         return function(branch, start_point)
           return tbl.args(branch, start_point).b()
+        end
+      end,
+      file = function(tbl)
+        return function(file)
+          return tbl.args(file)
         end
       end,
     },

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -120,6 +120,7 @@ local configurations = {
       name_only = "--name-only",
       no_ext_diff = "--no-ext-diff",
       no_index = "--no-index",
+      check = "--check",
     },
   },
 

--- a/lua/neogit/lib/git/index.lua
+++ b/lua/neogit/lib/git/index.lua
@@ -117,7 +117,13 @@ end
 -- Do this manually since the `cli` add --no-optional-locks
 function M.update()
   require("neogit.process")
-    .new({ cmd = { "git", "update-index", "-q", "--refresh" }, verbose = true })
+    .new({
+      cmd = { "git", "update-index", "-q", "--refresh" },
+      verbose = false,
+      on_error = function(_)
+        return false
+      end,
+    })
     :spawn_async()
 end
 

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -28,7 +28,7 @@ end
 ---@field stdin number|nil
 ---@field pty boolean|nil
 ---@field on_partial_line fun(process: Process, data: string, raw: string)|nil callback on complete lines
----@field on_error (fun(res: ProcessResult): boolean) Intercept the error externally, returning true prevents the error from being logged
+---@field on_error (fun(res: ProcessResult): boolean) Intercept the error externally, returning false prevents the error from being logged
 local Process = {}
 Process.__index = Process
 

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -26,8 +26,8 @@ end
 ---@field result ProcessResult|nil
 ---@field job number|nil
 ---@field stdin number|nil
----@field pty boolean
----@field on_partial_line fun(process: Process, data: string, raw: string) callback on complete lines
+---@field pty boolean|nil
+---@field on_partial_line fun(process: Process, data: string, raw: string)|nil callback on complete lines
 ---@field on_error (fun(res: ProcessResult): boolean) Intercept the error externally, returning true prevents the error from being logged
 local Process = {}
 Process.__index = Process

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -1001,6 +1001,21 @@ local discard = operation("discard", function()
         end
       else
         logger.fmt_debug("Discarding in section %s %s", section_name, item.name)
+        if item.mode == "UU" then
+          local choices = { "&ours", "&theirs", "&abort" }
+          local choice =
+            input.get_choice("Discard conflict by taking...", { values = choices, default = #choices })
+          if choice == "o" then
+            git.cli.checkout.ours.file(item.absolute_path).call_sync()
+          elseif choice == "t" then
+            git.cli.checkout.theirs.file(item.absolute_path).call_sync()
+          else
+            return
+          end
+          git.status.stage { item.name }
+          M.refresh(false, "Resolved conflict")
+          return
+        end
         table.insert(t, function()
           if section_name == "untracked" then
             a.util.scheduler()

--- a/tests/specs/neogit/status_spec.lua
+++ b/tests/specs/neogit/status_spec.lua
@@ -2,8 +2,9 @@ local a = require("plenary.async")
 local eq = assert.are.same
 local status = require("neogit.status")
 local operations = require("neogit.operations")
+local util = require("tests.util.util")
 local harness = require("tests.util.git_harness")
-local _ = require("tests.mocks.input")
+local input = require("tests.mocks.input")
 local in_prepared_repo = harness.in_prepared_repo
 local get_git_status = harness.get_git_status
 local get_git_diff = harness.get_git_diff
@@ -17,9 +18,10 @@ local function find(text)
   for index, line in ipairs(vim.api.nvim_buf_get_lines(0, 0, -1, true)) do
     if line:match(text) then
       vim.api.nvim_win_set_cursor(0, { index, 0 })
-      break
+      return true
     end
   end
+  return false
 end
 
 describe("status buffer", function()
@@ -363,6 +365,75 @@ describe("status buffer", function()
 ]],
           get_git_diff("b.txt", "--cached")
         )
+      end)
+    )
+    local function produce_merge_conflict(file, change)
+      util.system("git commit -am 'WIP'")
+      util.system("git switch second-branch")
+      util.system("sed -i '" .. change .. "' " .. file)
+      util.system("git commit -am 'conflict'")
+      util.system("git merge master", true)
+      eq("UU " .. file, get_git_status(file))
+      a.util.block_on(status.reset)
+      a.util.block_on(status.refresh)
+      eq(true, find("Both Modified"))
+    end
+    it(
+      "can discard a conflicted file with [O]urs",
+      in_prepared_repo(function()
+        produce_merge_conflict("a.txt", "s/manipulated/MANIPULATED/g")
+        input.choice = "o"
+
+        act("x")
+        operations.wait("discard")
+
+        eq("", get_git_status("a.txt"))
+        util.system(
+          "grep -q MANIPULATED a.txt",
+          false,
+          "Expected that after taking OUR changes we have 'MANIPULATED' in 'a.txt'"
+        )
+      end)
+    )
+    it(
+      "can discard a conflicted file with [T]heirs",
+      in_prepared_repo(function()
+        produce_merge_conflict("a.txt", "s/manipulated/MANIPULATED/g")
+        input.choice = "t"
+
+        act("x")
+        operations.wait("discard")
+
+        eq("M  a.txt", get_git_status("a.txt"))
+        util.system(
+          "grep -vq MANIPULATED a.txt",
+          false,
+          "Expected that after taking THEIR changes we don't have 'MANIPULATED' in 'a.txt' anymore"
+        )
+      end)
+    )
+    it(
+      "can abort discarding a conflicted file, leaving it conflicted",
+      in_prepared_repo(function()
+        produce_merge_conflict("a.txt", "s/manipulated/MANIPULATED/g")
+        input.choice = "a"
+
+        act("x")
+        operations.wait("discard")
+
+        eq("UU a.txt", get_git_status("a.txt"))
+      end)
+    )
+    it(
+      "quitting choice prompt does abort discard of conflicted file",
+      in_prepared_repo(function()
+        produce_merge_conflict("a.txt", "s/manipulated/MANIPULATED/g")
+        input.choice = nil -- simulate user pressed ESC
+
+        act("x")
+        operations.wait("discard")
+
+        eq("UU a.txt", get_git_status("a.txt"))
       end)
     )
   end)


### PR DESCRIPTION
Hi @CKolkey, me again (=

AFAIK so far there is no option to discard files which are in conflict. I really liked the Magit way of handling this, that is asking the user to use "ours" or "theirs", so I recreated that behavior in Neogit. 

[Neogit-discard-conflict.webm](https://github.com/NeogitOrg/neogit/assets/31999281/d26bd443-6562-40a7-be28-9ac5b9435d48)


## Notes

1. This does not work yet rebased on master, because of #1176. Best is not to merge before this is fixed
2. This does only for for entire files up to now. Discarding conflicted hunks does not work. I want to try this next, but have to understand the "patching" logic for hunks. Ideas/explanations welcome