### PR TITLE
Use ; and , to scroll commit view inside log view

### DIFF
--- a/lua/neogit/buffers/log_view/init.lua
+++ b/lua/neogit/buffers/log_view/init.lua
@@ -135,6 +135,24 @@ function M:open()
         ["<enter>"] = function()
           CommitViewBuffer.new(self.buffer.ui:get_commit_under_cursor(), self.files):open()
         end,
+        [";"] = function()
+          if self.buffer and self.buffer.ui then
+            local commit_id = self.buffer.ui:get_commit_under_cursor()
+            CommitViewBuffer.open_or_run_in_window(commit_id, self.files, function(window_id)
+              local key = vim.api.nvim_replace_termcodes("<C-d>", true, false, true)
+              vim.fn.win_execute(window_id, "normal! " .. key)
+            end)
+          end
+        end,
+        [","] = function()
+          if self.buffer and self.buffer.ui then
+            local commit_id = self.buffer.ui:get_commit_under_cursor()
+            CommitViewBuffer.open_or_run_in_window(commit_id, self.files, function(window_id)
+              local key = vim.api.nvim_replace_termcodes("<C-u>", true, false, true)
+              vim.fn.win_execute(window_id, "normal! " .. key)
+            end)
+          end
+        end,
         ["<c-k>"] = function(buffer)
           local stack = self.buffer.ui:get_component_stack_under_cursor()
           local c = stack[#stack]


### PR DESCRIPTION
When viewing the commit log, pressing `;` or `,` can be used to open the commit view without focusing it. If you press `;` again, it will scroll down the commit view. With `,` you can scroll up. Because the commit view window isn't focused, you can quickly focus the next commit with `j` or the previous with `k`.

This reduces the amount of key presses significantly when reviewing changes of multiple commits because you don't have to switch windows twice for every commit you want to look at.

Since `f` and `t` are bound differently to normal vim usage, `;` and `,` are also basically free to use. On the US layout (and others), you only need the right hand to review the changes and can use the left hand to drink coffee or tee. ;-)

These bindings implement the same functionality as `magit-diff-show-or-scroll-down` and `magit-diff-show-or-scroll-up`.

This workflow is something that I've grown very accustomed to and one of the reasons I'm still using (Doom) Emacs at work. I also think, that it is useful for other people, so I've opened this PR. This is literally my whole magit-configuration:

```emacs-lisp
(map!
 :map magit-log-mode-map
 :g ";" 'magit-diff-show-or-scroll-down
 :g "," 'magit-diff-show-or-scroll-up
 )
```
