### PR TITLE
Various fix for finder's prompt

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -219,7 +219,7 @@ function Finder:find(on_select)
   elseif config.check_integration("fzf_lua") then
     local fzf_lua = require("fzf-lua")
     fzf_lua.fzf_exec(self.entries, {
-      prompt = string.format(" %s > ", self.opts.prompt_prefix),
+      prompt = string.format("%s> ", self.opts.prompt_prefix),
       fzf_opts = fzf_opts(self.opts),
       winopts = {
         height = self.opts.layout_config.height,
@@ -228,7 +228,7 @@ function Finder:find(on_select)
     })
   else
     vim.ui.select(self.entries, {
-      prompt = string.format(" %s > ", self.opts.prompt_prefix),
+      prompt = string.format("%s: ", self.opts.prompt_prefix),
       format_item = function(entry)
         return entry
       end,

--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -178,10 +178,6 @@ Finder.__index = Finder
 ---@param opts FinderOpts
 ---@return Finder
 function Finder:new(opts)
-  if opts.prompt_prefix then
-    opts.prompt_prefix = string.format(" %s > ", opts.prompt_prefix)
-  end
-
   local this = {
     opts = vim.tbl_deep_extend("keep", opts, default_opts()),
     entries = {},
@@ -210,6 +206,8 @@ function Finder:find(on_select)
     local pickers = require("telescope.pickers")
     local finders = require("telescope.finders")
     local sorters = require("telescope.sorters")
+
+    self.opts.prompt_prefix = string.format(" %s > ", self.opts.prompt_prefix)
 
     pickers
       .new(self.opts, {

--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -149,7 +149,7 @@ local function default_opts()
     refocus_status = true,
     allow_multi = false,
     border = false,
-    prompt_prefix = " > ",
+    prompt_prefix = "select",
     previewer = false,
     cache_picker = false,
     layout_strategy = "bottom_pane",


### PR DESCRIPTION
This PR includes three commits, explained here.

### 1. Change the default prompt_prefix value
The default value of the `prompt_prefix` is an indicator `" > "`:
https://github.com/NeogitOrg/neogit/blob/0d0879b0045fb213c328126969a3317c0963d34a/lua/neogit/lib/finder.lua#L152

But whenever the `Finder` was created, it added an indicator as a postfix also:
https://github.com/NeogitOrg/neogit/blob/0d0879b0045fb213c328126969a3317c0963d34a/lua/neogit/lib/finder.lua#L182

So the default value of `prompt_prefix` for users will be `" > > "`, I change the default value to a more meaningful value in this commit.

### 2. Remove redundant prompt_prefix postfix
The behavior of adding a postfix for every `prompt_prefix` has problems too. Because neogit do it whenever the `Finder` is created:
https://github.com/NeogitOrg/neogit/blob/0d0879b0045fb213c328126969a3317c0963d34a/lua/neogit/lib/finder.lua#L182
And when the finder is not telescope.nvim, it will add the postfix again:
https://github.com/NeogitOrg/neogit/blob/0d0879b0045fb213c328126969a3317c0963d34a/lua/neogit/lib/finder.lua#L224
https://github.com/NeogitOrg/neogit/blob/0d0879b0045fb213c328126969a3317c0963d34a/lua/neogit/lib/finder.lua#L233

So this behavior is redundant in this situation. There are two ways to fix this indeed,
1. Do not add the postfix whenever the `Finder` is created;
2. Do not add the postfix when the `Finder` is not telescope.nvim also. 

I selected the second way to complete the third commit.

### 3. Modify postfix for finders
For telescope.nvim, maybe the prefix space is needed, but for fzf-lua, it is redundant, so I removed it, and for `vim.ui.select`, even though there's no standard to specify what the prompt postfix is, most plugins select a colon. Most importantly, the popular plugin dressing.nvim which is dedicated to customizing `vim.ui.*` will trim if the end is a colon in some situations to be more beautiful.


