### PR TITLE
Improve parsing of url's in all cases, but specifically for ssh cases.

### DIFF
--- a/lua/neogit/lib/git/remote.lua
+++ b/lua/neogit/lib/git/remote.lua
@@ -94,7 +94,7 @@ function M.parse(url)
       info.path = url:sub(#info.proto + 4, #url):match([[/(.*)/]])
       info.owner = info.path -- Strictly for backwards compatibility.
     end
-    info.repo = url:match([[/(%w+).git]])
+    info.repo = url:match([[/(%w+)%.git]])
   end
   info.repository = info.repo
   return info

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -274,12 +274,6 @@ M.delete_branch = operation("delete_branch", function()
   end
 end)
 
-local function parse_remote_info(service, url)
-  local delim = url:sub(1, 6) == "ssh://" and "/" or ":"
-  local _, _, owner, repo = string.find(url, string.format("%s[^%s]*%s(.+)/(.+)", service, delim, delim))
-  repo, _ = repo:gsub(".git$", "")
-  return { repository = repo, owner = owner, branch_name = git.branch.current() }
-end
 
 M.open_pull_request = operation("open_pull_request", function()
   local template, service

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -274,14 +274,12 @@ M.delete_branch = operation("delete_branch", function()
   end
 end)
 
-
 M.open_pull_request = operation("open_pull_request", function()
-  local template, service
+  local template
   local url = git.remote.get_url(git.branch.upstream_remote())[1]
 
   for s, v in pairs(config.values.git_services) do
     if url:match(s) then
-      service = s
       template = v
       break
     end
@@ -289,7 +287,9 @@ M.open_pull_request = operation("open_pull_request", function()
 
   if template then
     if vim.ui.open then
-      vim.ui.open(util.format(template, parse_remote_info(service, url)))
+      local fmt_vals = git.remote.parse(url)
+      fmt_vals["branch_name"] = git.branch.current()
+      vim.ui.open(util.format(template, fmt_vals))
     else
       notification.warn("Requires Neovim 0.10")
     end

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -275,7 +275,8 @@ M.delete_branch = operation("delete_branch", function()
 end)
 
 local function parse_remote_info(service, url)
-  local _, _, owner, repo = string.find(url, service .. ".(.+)/(.+)")
+  local delim = url:sub(1, 6) == "ssh://" and "/" or ":"
+  local _, _, owner, repo = string.find(url, string.format("%s[^%s]*%s(.+)/(.+)", service, delim, delim))
   repo, _ = repo:gsub(".git$", "")
   return { repository = repo, owner = owner, branch_name = git.branch.current() }
 end


### PR DESCRIPTION
In my case, in addition to the default git_services, I use a hosted
Gitlab that uses some ssh tunneling to reach the destination using a
port other than standard. Using the parsing as is results in parsing the
owner as `<port>/actual/owner`. For example ssh://gitlab.priv:2222/priv/group/repo.git
yields owner `2222/priv/group` which constructs a bad url with
configuration `["gitlab.priv"] = "https://gitlab.priv/${owner}/${repository}/-/merge_requests/new?merge_request[source_branch]=${branch_name}&merge_request[target_branch]=main"`.

This probably generally works, because most users of ssh remotes will
either use the git scheme or the default port 22, without specifying.

This patch introduces a more robust git url parsing library function, with support for more url schemes. It also maintains compatibility with the existing implementation where owner is set to the entire path part which is not the repository name; which is correct in the basic gitlab / github cases, but not in many other git cases.

It has been tested with the following url's:

- `git@github.com:owner/repo.git`
- `https://github.com/owner/repo.git`
- `git@gitlab.com:owner/repo.git`
- `https://gitlab.com/owner/repo.git`
- `ssh://git@gitlab.priv/project/path/repo.git`
- `ssh://git@gitlab.priv:2222/project/path/repo.git`
- `ssh://git:pass@gitlab.priv:2222/project/path/repo.git`
- `https://gitlab.priv/project/path/repo.git`
- `https://gitlab.priv:4443/project/path/repo.git`

<details>

<summary>Test Results</summary>

```bash
{
  host = "github.com",
  owner = "owner",
  proto = "git",
  repo = "repo",
  repository = "repo",
  url = "git@github.com:owner/repo.git",
  user = "git"
}
{
  host = "github.com",
  owner = "owner",
  path = "owner",
  proto = "https",
  repo = "repo",
  repository = "repo",
  url = "https://github.com/owner/repo.git"
}
{
  host = "gitlab.com",
  owner = "owner",
  proto = "git",
  repo = "repo",
  repository = "repo",
  url = "git@gitlab.com:owner/repo.git",
  user = "git"
}
{
  host = "gitlab.com",
  owner = "owner",
  path = "owner",
  proto = "https",
  repo = "repo",
  repository = "repo",
  url = "https://gitlab.com/owner/repo.git"
}
{
  host = "gitlab.priv",
  owner = "project/path",
  path = "project/path",
  proto = "ssh",
  repo = "repo",
  repository = "repo",
  url = "ssh://git@gitlab.priv/project/path/repo.git",
  user = "git"
}
{
  host = "gitlab.priv",
  owner = "project/path",
  path = "project/path",
  port = "2222",
  proto = "ssh",
  repo = "repo",
  repository = "repo",
  url = "ssh://git@gitlab.priv:2222/project/path/repo.git",
  user = "git"
}
{
  host = "gitlab.priv",
  owner = "project/path",
  path = "project/path",
  port = "2222",
  proto = "ssh",
  repo = "repo",
  repository = "repo",
  url = "ssh://git:pass@gitlab.priv:2222/project/path/repo.git",
  user = "git"
}
{
  host = "gitlab.priv",
  owner = "project/path",
  path = "project/path",
  proto = "https",
  repo = "repo",
  repository = "repo",
  url = "https://gitlab.priv/project/path/repo.git"
}
{
  host = "gitlab.priv",
  owner = "project/path",
  path = "project/path",
  port = "4443",
  proto = "https",
  repo = "repo",
  repository = "repo",
  url = "https://gitlab.priv:4443/project/path/repo.git"
}
```

</details>

And now it works as expected with the following configuration:

```lua
      git_services = {
        ["github.com"] = "https://github.com/${owner}/${repository}/compare/${branch_name}?expand=1",
        ["gitlab.com"] = "https://gitlab.com/${owner}/${repository}/merge_requests/new?merge_request[source_branch]=${branch_name}",
        ["gitlab.priv"] = "https://gitlab.priv/${path}/${repository}/-/merge_requests/new?merge_request[source_branch]=${branch_name}&merge_request[target_branch]=main",
      },
```

Lastly, the test are passing to the same extent they were before this patch.