### PR TITLE
Fix issue where owner and repo have special characters.

### DIFF
--- a/lua/neogit/lib/git/remote.lua
+++ b/lua/neogit/lib/git/remote.lua
@@ -83,7 +83,7 @@ function M.parse(url)
     if protocol == "git" then
       user = "git"
       host = url:match([[@([^:]+)]])
-      owner = url:match([[:(%w+)/]])
+      owner = url:match([[:([^/]+)/]])
     else
       user = url:match([[://(%w+):?%w*@]]) -- Strip passwords.
       port = url:match([[:(%d+)]])
@@ -102,7 +102,7 @@ function M.parse(url)
       owner = path -- Strictly for backwards compatibility.
     end
 
-    repository = url:match([[/(%w+)%.git]])
+    repository = url:match([[/([^/]+)%.git]])
   end
 
   return {

--- a/tests/specs/neogit/lib/git/remote_spec.lua
+++ b/tests/specs/neogit/lib/git/remote_spec.lua
@@ -133,5 +133,33 @@ describe("lib.git.remote", function()
         url = "https://gitlab.priv:4443/project/path/repo.git",
       })
     end)
+
+    it("can parse 'git@github.com:owner-with-dashes/repo.git'", function()
+      local url = "git@github.com:owner-with-dashes/repo.git"
+
+      assert.are.same(git.remote.parse(url), {
+        host = "github.com",
+        owner = "owner-with-dashes",
+        protocol = "git",
+        repo = "repo",
+        repository = "repo",
+        url = "git@github.com:owner-with-dashes/repo.git",
+        user = "git",
+      })
+    end)
+
+    it("can parse 'git@github.com:owner/repo-with_specials.git'", function()
+      local url = "git@github.com:owner/repo-with_specials.git"
+
+      assert.are.same(git.remote.parse(url), {
+        host = "github.com",
+        owner = "owner",
+        protocol = "git",
+        repo = "repo-with_specials",
+        repository = "repo-with_specials",
+        url = "git@github.com:owner/repo-with_specials.git",
+        user = "git",
+      })
+    end)
   end)
 end)


### PR DESCRIPTION
988b2869 introduced a regression where special characters prevented making complete matches. This changes those match patterns to all non-slash characters rather than word characters.

<details>

<summary>Verification output</summary>

```bash
{
  host = "github.com",
  owner = "owner-with-dash",
  proto = "git",
  repo = "repo",
  repository = "repo",
  url = "git@github.com:owner-with-dash/repo.git",
  user = "git"
}
{
  host = "github.com",
  owner = "owner",
  proto = "git",
  repo = "repo-with-dash",
  repository = "repo-with-dash",
  url = "git@github.com:owner/repo-with-dash.git",
  user = "git"
}
```

</details>