### PR TITLE
Rebase drop a commit

### DIFF
--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -514,8 +514,4 @@ function M.reflog_message(skip)
     .call_sync({ ignore_error = true }).stdout
 end
 
-function M.abbreviated_size()
-  return string.len(cli.log.format("%h").max_count(1).call({ hidden = true }).stdout[1])
-end
-
 return M

--- a/lua/neogit/lib/git/rebase.lua
+++ b/lua/neogit/lib/git/rebase.lua
@@ -106,6 +106,20 @@ function M.modify(commit)
   fire_rebase_event { commit = commit, status = "ok" }
 end
 
+function M.drop(commit)
+  local short_commit = require("neogit.lib.git").rev_parse.abbreviate_commit(commit)
+  local editor = "nvim -c '%s/^pick \\(" .. short_commit .. ".*\\)/drop \\1/' -c 'wq'"
+  local result = cli.rebase
+    .env({ GIT_SEQUENCE_EDITOR = editor }).interactive.autosquash.autostash
+    .in_pty(true)
+    .commit(commit)
+    .call()
+  if result.code ~= 0 then
+    return
+  end
+  fire_rebase_event { commit = commit, status = "ok" }
+end
+
 function M.continue()
   return rebase_command(cli.rebase.continue)
 end

--- a/lua/neogit/lib/git/rebase.lua
+++ b/lua/neogit/lib/git/rebase.lua
@@ -2,7 +2,6 @@ local logger = require("neogit.logger")
 local client = require("neogit.client")
 local notification = require("neogit.lib.notification")
 local cli = require("neogit.lib.git.cli")
-local log = require("neogit.lib.git.log")
 
 local M = {}
 
@@ -94,7 +93,7 @@ function M.reword(commit, message)
 end
 
 function M.modify(commit)
-  local short_commit = string.sub(commit, 1, log.abbreviated_size())
+  local short_commit = require("neogit.lib.git").rev_parse.abbreviate_commit(commit)
   local editor = "nvim -c '%s/^pick \\(" .. short_commit .. ".*\\)/edit \\1/' -c 'wq'"
   local result = cli.rebase
     .env({ GIT_SEQUENCE_EDITOR = editor }).interactive.autosquash.autostash

--- a/lua/neogit/popups/rebase/actions.lua
+++ b/lua/neogit/popups/rebase/actions.lua
@@ -130,6 +130,20 @@ M.modify = operation("rebase_modify", function(popup)
   status.refresh(nil, "rebase_modify")
 end)
 
+M.drop = operation("rebase_drop", function(popup)
+  local commit
+  if popup.state.env.commit then
+    commit = popup.state.env.commit
+  else
+    commit = CommitSelectViewBuffer.new(git.log.list()):open_async()[1]
+    if not commit then
+      return
+    end
+  end
+  git.rebase.drop(commit)
+  status.refresh(nil, "drop")
+end)
+
 function M.subset(popup)
   local newbase = FuzzyFinderBuffer.new(git.branch.get_all_branches())
     :open_async { prompt_prefix = "rebase subset onto" }

--- a/lua/neogit/popups/rebase/init.lua
+++ b/lua/neogit/popups/rebase/init.lua
@@ -42,7 +42,7 @@ function M.create(env)
     :new_action_group_if(not in_rebase)
     :action_if(not in_rebase, "m", "to modify a commit", actions.modify)
     :action_if(not in_rebase, "w", "to reword a commit", actions.reword)
-    :action_if(not in_rebase, "k", "to remove a commit")
+    :action_if(not in_rebase, "d", "to remove a commit", actions.drop)
     :action_if(not in_rebase, "f", "to autosquash")
     :env({
       commit = env.commit,

--- a/tests/specs/neogit/popups/rebase_spec.lua
+++ b/tests/specs/neogit/popups/rebase_spec.lua
@@ -42,6 +42,38 @@ describe("rebase popup", function()
     assert.are.same(new_head, git.rev_parse.oid("HEAD"))
   end
 
+  function test_drop(commit_to_drop, selected)
+    local dropped_commit = git.rev_parse.oid(commit_to_drop)
+    if selected == false then
+      CommitSelectViewBufferMock.add(git.rev_parse.oid(commit_to_drop))
+    end
+    act("rd<cr>")
+    operations.wait("rebase_drop")
+    assert.is_not.same(dropped_commit, git.rev_parse.oid(commit_to_drop))
+  end
+
+  it(
+    "rebase to drop HEAD",
+    in_prepared_repo(function()
+      test_drop("HEAD", false)
+    end)
+  )
+  it(
+    "rebase to drop HEAD~1",
+    in_prepared_repo(function()
+      test_drop("HEAD~1", false)
+    end)
+  )
+  it(
+    "rebase to drop HEAD~1 from log view",
+    in_prepared_repo(function()
+      act("ll") -- log commits
+      operations.wait("log_current")
+      act("j") -- go down one commit
+      test_drop("HEAD~1", true)
+    end)
+  )
+
   it(
     "rebase to reword HEAD",
     in_prepared_repo(function()


### PR DESCRIPTION
Based on [this](https://github.com/NeogitOrg/neogit/commit/a5d5cc68dcd844eedc2db5a7c399dbec6ef1d49d) we can now also drop a commit.

I suggest to change the keybinding for dropping to "d" since it's unused in that view and feels more natural.