### PR TITLE
Fix status when files have conflicts

### DIFF
--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -1,5 +1,4 @@
 local Path = require("plenary.path")
-local util = require("neogit.lib.util")
 local Collection = require("neogit.lib.collection")
 
 ---@class File: StatusItem

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -54,19 +54,22 @@ local function update_status(state)
 
   local result = git.cli.status.null_separated.porcelain(2).branch.call { hidden = true }
   result = vim.split(result.stdout_raw[1], "\n")
-  result = util.collect(result, function(line, collection)
-    if line == "" then
-      return
-    end
 
-    if line ~= "" and (line:match("^[12u]%s[MTADRC%s%.%?!][MTDRC%s%.%?!]%s") or line:match("^[%?!#]%s")) then
+  local collection = {}
+  local line_nr = 1
+  local prev_line = nil
+  repeat
+    local line = result[line_nr]
+    if line:match("^[12u]%s[MTADRCU%s%.%?!][MTDRCU%s%.%?!]%s") or line:match("^[%?!#]%s") then
       table.insert(collection, line)
-    else
+    elseif prev_line and prev_line:match("2%sR%.%s") then
       collection[#collection] = ("%s\t%s"):format(collection[#collection], line)
     end
-  end)
+    line_nr = line_nr + 1
+    prev_line = line
+  until line_nr > #result
 
-  for _, l in ipairs(result) do
+  for _, l in ipairs(collection) do
     local header, value = l:match("# ([%w%.]+) (.+)")
     if header then
       if header == "branch.head" then


### PR DESCRIPTION
The bug was that in a repo which has both a conflict and a renamed file `git status -z --porcelain=2 -b` will report:

```sh
# branch.oid dbb8571c4f873daff059c04443077b43a703338a
# branch.head (detached)
2 R. N... 100644 100644 100644 cd4e4e1ada23361e9ad886a5723bda3aa9419ea8 cd4e4e1ada23361e9ad886a5723bda3aa9419ea8 R100 c.txt
a.txt
u UU N... 100644 100644 100644 100644 15b4f7fdbd22faf05ee23ec5c3a98c775657fe18 7513f79749fe4a5c1942b1f89de63c128a0fedcd d5a2e9b772aa39468c69670ad9bd319bbf197a86 b.txt
```

and that does not match the pattern in:
`    if line:match("^[12u]%s[MTADRCU%s%.%?!][MTDRCU%s%.%?!]%s") or line:match("^[%?!#]%s") then`
so it falls through to the else which appends the unmatched line to the previous line.

The else statement is there to handle renamed files which end up on separate lines so I changed the for loop from a simple one-by-one loop to a loop that can look at the previous line. If the previous line is a "this file was renamed", i.e. matches: `^2 R.`, then append the current line, which contains the old file, to the previous line and move on.

This fixes #1176