### PR TITLE
Fix: merge conflict missing files: added by them

### DIFF
--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -59,7 +59,7 @@ local function update_status(state)
   local prev_line = nil
   repeat
     local line = result[line_nr]
-    if line:match("^[12u]%s[MTADRCU%s%.%?!][MTDRCU%s%.%?!]%s") or line:match("^[%?!#]%s") then
+    if line:match("^[12u]%s[MTADRCU%s%.%?!][MTADRCU%s%.%?!]%s") or line:match("^[%?!#]%s") then
       table.insert(collection, line)
     elseif prev_line and prev_line:match("2%sR%.%s") then
       collection[#collection] = ("%s\t%s"):format(collection[#collection], line)

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -1022,7 +1022,7 @@ local discard = operation("discard", function()
         end
       else
         logger.fmt_debug("Discarding in section %s %s", section_name, item.name)
-        if item.mode == "UU" then
+        if item.mode:match("^[UA][AU]") then
           local choices = { "&ours", "&theirs", "&abort" }
           local choice =
             input.get_choice("Discard conflict by taking...", { values = choices, default = #choices })


### PR DESCRIPTION
Hi,

first time PR, small one.

This fixes: #1222

I had a fix for  #1176, but then realized that was solved today , already :)  

So, I took the learning experience to fix another: #1222

During a merge conflict, when the mode is UA: unmerged, added by them, the case was missing and not displaying in the status buffer. Also used #1189, to use discard (keybind x)  to choose between ours/theirs version, which was not available for UA or AU cases. 

Hope it helps, :) 

