### PR TITLE
Status buffer fixes

### DIFF
--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -14,6 +14,10 @@ local range = util.range
 
 local M = {}
 
+M.EmptyLine = Component.new(function()
+  return col { row { text("") } }
+end)
+
 local diff_add_start = "+"
 local diff_delete_start = "-"
 

--- a/lua/neogit/buffers/status/init.lua
+++ b/lua/neogit/buffers/status/init.lua
@@ -405,17 +405,6 @@ function M:open(kind, cwd)
         [mappings["Toggle"]] = function()
           local fold = self.buffer.ui:get_fold_under_cursor()
           if fold then
-            -- Do not allow folding on the last (empty) line of a section. It should be considered "not part of either
-            -- section" from a UX perspective. Only applies to unfolded sections.
-            if
-              fold.options.tag == "Section"
-              and not fold.options.folded
-              and self.buffer:get_current_line()[1] == ""
-            then
-              logger.info("Toggle early return")
-              return
-            end
-
             if fold.options.on_open then
               fold.options.on_open(fold, self.buffer.ui)
             else

--- a/lua/neogit/buffers/status/init.lua
+++ b/lua/neogit/buffers/status/init.lua
@@ -390,11 +390,6 @@ function M:open(kind, cwd)
           if self.buffer:get_current_line()[1] == "" then
             vim.cmd("norm! j")
           end
-
-          -- TODO: The renderer should trim the last empty line instead of this
-          if self.buffer:cursor_line() == fn.line("$") then
-            vim.cmd("norm! k")
-          end
         end,
         ["k"] = function()
           if vim.v.count > 0 then

--- a/lua/neogit/buffers/status/ui.lua
+++ b/lua/neogit/buffers/status/ui.lua
@@ -10,9 +10,9 @@ local text = Ui.text
 
 local map = util.map
 
+local EmptyLine = common.EmptyLine
 local List = common.List
 local DiffHunks = common.DiffHunks
-local EmptyLine = col { row { text("") } }
 
 local M = {}
 
@@ -161,7 +161,7 @@ local Section = Component.new(function(props)
   return col.tag("Section")({
     row(util.merge(props.title, { text(" ("), text(#props.items), text(")") })),
     col(map(props.items, props.render)),
-    EmptyLine,
+    EmptyLine(),
   }, {
     foldable = true,
     folded = props.folded,
@@ -174,7 +174,7 @@ local SequencerSection = Component.new(function(props)
   return col.tag("Section")({
     row(util.merge(props.title)),
     col(map(props.items, props.render)),
-    EmptyLine,
+    EmptyLine(),
   }, {
     foldable = true,
     folded = props.folded,
@@ -193,7 +193,7 @@ local RebaseSection = Component.new(function(props)
       text(")"),
     })),
     col(map(props.items, props.render)),
-    EmptyLine,
+    EmptyLine(),
   }, {
     foldable = true,
     folded = props.folded,
@@ -373,12 +373,12 @@ local BisectDetailsSection = Component.new(function(props)
       text((props.commit.committer_name or "") .. " <" .. (props.commit.committer_email or "") .. ">"),
     },
     row { text.highlight("Comment")("CommitDate: "), text(props.commit.committer_date) },
-    EmptyLine,
+    EmptyLine(),
     col(
       map(props.commit.description, text),
       { highlight = "NeogitCommitViewDescription", tag = "Description" }
     ),
-    EmptyLine,
+    EmptyLine(),
   }, {
     foldable = true,
     folded = props.folded,
@@ -452,7 +452,7 @@ function M.Status(state, config)
     List {
       items = {
         show_hint and HINT { config = config },
-        show_hint and EmptyLine,
+        show_hint and EmptyLine(),
         HEAD {
           name = "Head",
           branch = state.head.branch,
@@ -482,7 +482,7 @@ function M.Status(state, config)
           distance = show_tag_distance and state.head.tag.distance,
           yankable = state.head.tag.oid,
         },
-        EmptyLine,
+        EmptyLine(),
         show_merge and SequencerSection {
           title = SectionTitleMerge { title = "Merging", branch = state.merge.branch },
           render = SectionItemSequencer,

--- a/lua/neogit/buffers/status/ui.lua
+++ b/lua/neogit/buffers/status/ui.lua
@@ -71,10 +71,12 @@ local HINT = Component.new(function(props)
 end)
 
 local HEAD = Component.new(function(props)
+  local show_oid = props.show_oid
   local highlight, ref
   if props.branch == "(detached)" then
-    highlight = "Comment"
-    ref = props.oid
+    highlight = "NeogitBranch"
+    ref = props.branch
+    show_oid = true
   elseif props.remote then
     highlight = "NeogitRemote"
     ref = ("%s/%s"):format(props.remote, props.branch)
@@ -83,10 +85,17 @@ local HEAD = Component.new(function(props)
     ref = props.branch
   end
 
+  local oid = props.yankable
+  if not oid or oid == "(initial)" then
+    oid = "0000000"
+  else
+    oid = oid:sub(1, 7)
+  end
+
   return row({
     text(util.pad_right(props.name .. ":", 10)),
-    text.highlight("Comment")(props.show_oid and props.yankable:sub(1, 7) or ""),
-    text(props.show_oid and " " or ""),
+    text.highlight("Comment")(show_oid and oid or ""),
+    text(show_oid and " " or ""),
     text.highlight(highlight)(ref),
     text(" "),
     text(props.msg or "(no commits)"),

--- a/lua/neogit/lib/popup/ui.lua
+++ b/lua/neogit/lib/popup/ui.lua
@@ -4,6 +4,7 @@ local common = require("neogit.buffers.common")
 local Ui = require("neogit.lib.ui")
 local util = require("neogit.lib.util")
 
+local EmptyLine = common.EmptyLine
 local List = common.List
 local Grid = common.Grid
 local col = Ui.col
@@ -14,8 +15,6 @@ local Component = Ui.Component
 local intersperse = util.intersperse
 local filter_map = util.filter_map
 local map = util.map
-
-local EmptyLine = col { row { text("") } }
 
 -- Builds config component to be rendered
 ---@return table
@@ -237,7 +236,7 @@ function M.items(state)
 
   if state.config[1] then
     table.insert(items, Config { state = state.config })
-    table.insert(items, EmptyLine)
+    table.insert(items, EmptyLine())
   end
 
   if state.args[1] then
@@ -251,7 +250,7 @@ function M.items(state)
       elseif item.type == "heading" then
         if section[1] then -- If there are items in the section, flush to items table with current name
           table.insert(items, Section(name, section))
-          table.insert(items, EmptyLine)
+          table.insert(items, EmptyLine())
           section = {}
         end
 
@@ -260,7 +259,7 @@ function M.items(state)
     end
 
     table.insert(items, Section(name, section))
-    table.insert(items, EmptyLine)
+    table.insert(items, EmptyLine())
   end
 
   if state.actions[1] then


### PR DESCRIPTION
This fixes the issues with `<Tab>` in blank spaces. The problem is that the `EmptyLine` component was actually an *instance* of a component, and that instance was being shared between all the sections in the status buffer. That means that when the component tree is rendered, that single instance gets added to `RendererIndex.index` multiple times, and its `position.row_start` field gets overwritten multiple times. This results in the `RendererIndex:find_by_line(line)` method returning a component with a `position.row_start` that is not equal to the `line` argument, and that breaks everything.

I've also fixed an error that pops up if the upstream or pushRemote branches don't have any commits, and made the Head line show `(detached)` again when detached. When detached, the commit hash will always be shown, irrespective of `show_head_commit_hash`. If `show_head_commit_hash` is enabled, and the branch doesn't have any commits, then it displays "0000000".

Ref: #1233