### PR TITLE
Add option to edit patch before staging

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -376,6 +376,7 @@ function M.get_default_values()
         ["s"] = "Stage",
         ["S"] = "StageUnstaged",
         ["<c-s>"] = "StageAll",
+        ["e"] = "StageEdit",
         ["u"] = "Unstage",
         ["U"] = "UnstageStaged",
         ["$"] = "CommandHistory",

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -292,6 +292,7 @@ local configurations = {
     flags = {
       update = "-u",
       all = "-A",
+      edit = "--edit",
     },
   },
 

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -186,6 +186,9 @@ local status = {
   stage_all = function()
     git.cli.add.all.call()
   end,
+  stage_edit = function(files, env)
+    return git.cli.add.edit.files(unpack(files)).env(env).show_popup(true):in_pty(true).call()
+  end,
   unstage = function(files)
     git.cli.reset.files(unpack(files)).call()
   end,


### PR DESCRIPTION
Hello! Thanks for this awesome plugin, I have been having a blast using it :)

I added a command to edit the patch before staging the file (shortcut `e`). This is equivalent to running `git add --edit -- file` in the command line. Do you guys have any interest in merging this?

In case this PR is missing something, I am willing to update it!