### PR TITLE
Fix error params in process.lua

### DIFF
--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -375,7 +375,7 @@ function Process:spawn(cb)
   })
 
   if job <= 0 then
-    error("Failed to start process: ", vim.inspect(self))
+    error("Failed to start process: " .. vim.inspect(self))
     if cb then
       cb(nil)
     end


### PR DESCRIPTION
Instead of concatenating it's passing the inspected object as a second parameter.

That's throwing an error when files are staged or branches switched from outside Neogit.