### PR TITLE
Added config value for relative line numbers

### DIFF
--- a/lua/neogit/buffers/rebase_editor/init.lua
+++ b/lua/neogit/buffers/rebase_editor/init.lua
@@ -76,6 +76,7 @@ function M:open(kind)
     kind = kind,
     modifiable = true,
     disable_line_numbers = config.values.disable_line_numbers,
+    disable_relative_line_numbers = config.values.disable_relative_line_numbers,
     readonly = false,
     initialize = function(buffer)
       vim.api.nvim_buf_attach(buffer.handle, false, {

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -146,6 +146,7 @@ end
 ---@field sort_branches? string Value used for `--sort` for the `git branch` command
 ---@field kind? WindowKind The default type of window neogit should open in
 ---@field disable_line_numbers? boolean Whether to disable line numbers
+---@field disable_relative_line_numbers? boolean Whether to disable line numbers
 ---@field console_timeout? integer Time in milliseconds after a console is created for long running commands
 ---@field auto_show_console? boolean Automatically show the console if a command takes longer than console_timeout
 ---@field status? { recent_commit_count: integer } Status buffer options
@@ -203,6 +204,7 @@ function M.get_default_values()
     sort_branches = "-committerdate",
     kind = "tab",
     disable_line_numbers = true,
+    disable_relative_line_numbers = true,
     -- The time after which an output console is shown for slow running commands
     console_timeout = 2000,
     -- Automatically show console if a command takes more than console_timeout milliseconds
@@ -770,6 +772,7 @@ function M.validate_config()
     validate_type(config.console_timeout, "console_timeout", "number")
     validate_kind(config.kind, "kind")
     validate_type(config.disable_line_numbers, "disable_line_numbers", "boolean")
+    validate_type(config.disable_relative_line_numbers, "disable_relative_line_numbers", "boolean")
     validate_type(config.auto_show_console, "auto_show_console", "boolean")
     if validate_type(config.status, "status", "table") then
       validate_type(config.status.recent_commit_count, "status.recent_commit_count", "number")

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -13,9 +13,11 @@ local Ui = require("neogit.lib.ui")
 ---@field ui Ui
 ---@field kind string
 ---@field disable_line_numbers boolean
+---@field disable_relative_line_numbers boolean
 local Buffer = {
   kind = "split",
   disable_line_numbers = true,
+  disable_relative_line_numbers = true,
 }
 Buffer.__index = Buffer
 
@@ -259,6 +261,9 @@ function Buffer:show()
 
   if self.disable_line_numbers then
     vim.cmd("setlocal nonu")
+  end
+
+  if self.disable_relative_line_numbers then
     vim.cmd("setlocal nornu")
   end
 
@@ -409,11 +414,14 @@ local uv_utils = require("neogit.lib.uv")
 ---@field swapfile boolean
 ---@field filetype string|nil
 ---@field disable_line_numbers boolean|nil
+---@field disable_relative_line_numbers boolean|nil
 ---@return Buffer
 function Buffer.create(config)
   config = config or {}
   local kind = config.kind or "split"
   local disable_line_numbers = (config.disable_line_numbers == nil) and true or config.disable_line_numbers
+  local disable_relative_line_numbers = (config.disable_relative_line_numbers == nil) and true
+    or config.disable_relative_line_numbers
   --- This reuses a buffer with the same name
   local buffer = fn.bufnr(config.name)
 
@@ -433,6 +441,7 @@ function Buffer.create(config)
   local buffer = Buffer:new(buffer)
   buffer.kind = kind
   buffer.disable_line_numbers = disable_line_numbers
+  buffer.disable_relative_line_numbers = disable_relative_line_numbers
 
   local win
   if config.open ~= false then

--- a/lua/neogit/status.lua
+++ b/lua/neogit/status.lua
@@ -1455,6 +1455,7 @@ function M.create(kind, cwd)
     filetype = "NeogitStatus",
     kind = kind,
     disable_line_numbers = config.values.disable_line_numbers,
+    disable_relative_line_numbers = config.values.disable_relative_line_numbers,
     ---@param buffer Buffer
     initialize = function(buffer, win)
       logger.debug("[STATUS BUFFER]: Initializing...")


### PR DESCRIPTION
The original source code only has one optional value for `disable_line_numbers`. This value initially controls both regular line numbers and relative line numbers if toggled `true/false`. 

I have added an additional config value of the name `disable_relative_line_numbers` with its default value set to `false` which will only control the relatively line number option. 

Each value can then be used independently to give the end-user's more flexibility. 