### PR TITLE
Use plenary.job to fix .git detection on windows, add regex fix for renamed files 

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -83,11 +83,11 @@ function M.open(opts)
   if not cli.is_inside_worktree(opts.cwd) then
     if
       input.get_confirmation(
-        string.format("Initialize repository in %s?", opts.cwd or vim.fn.getcwd()),
+        string.format("Initialize repository in %s?", opts.cwd),
         { values = { "&Yes", "&No" }, default = 2 }
       )
     then
-      lib.git.init.create(opts.cwd or vim.fn.getcwd(), true)
+      lib.git.init.create(opts.cwd, true)
     else
       notification.error("The current working directory is not a git repository")
       return

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -596,7 +596,7 @@ local is_inside_worktree = function(cwd)
   local args = { "rev-parse", "--is-inside-work-tree" }
   local returnval = false
   if cwd then
-    table.insert(args, { "-C", cwd })
+    args = { "-C", cwd, "rev-parse", "--is-inside-work-tree" }
   end
   job
     :new({

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -571,21 +571,24 @@ local configurations = {
 -- git_root_of_cwd() returns the git repo of the cwd, which can change anytime
 -- after git_root_of_cwd() has been called.
 local function git_root_of_cwd()
-  local process = process
-    .new({
-      cmd = { "git", "rev-parse", "--show-toplevel" },
-      on_error = function()
-        return false
+  local job = require("plenary.job")
+  local args = { "rev-parse", "--show-toplevel" }
+  local gitdir = Path:new(vim.fn.getcwd()):absolute() -- default to current directory
+  job
+    :new({
+      command = "git",
+      args = args,
+      on_exit = function(job_output, return_val)
+        if return_val == 0 then
+          -- Replace directory with the output of the git toplevel directory
+          gitdir = Path:new(job_output):absolute()
+        else
+          logger.warn("[CLI]: ", job_output)
+        end
       end,
     })
-    :spawn_blocking()
-
-  if process ~= nil and process.code == 0 then
-    local out = process.stdout[1]
-    return Path:new(out):absolute()
-  else
-    return ""
-  end
+    :sync()
+  return gitdir
 end
 
 local is_inside_worktree = function(cwd)

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -589,13 +589,24 @@ local function git_root_of_cwd()
 end
 
 local is_inside_worktree = function(cwd)
-  if not cwd then
-    vim.fn.system("git rev-parse --is-inside-work-tree")
-  else
-    vim.fn.system(string.format("git -C %q rev-parse --is-inside-work-tree", cwd))
+  local job = require("plenary.job")
+  local args = { "rev-parse", "--is-inside-work-tree" }
+  local returnval = false
+  if cwd then
+    table.insert(args, { "-C", cwd })
   end
-
-  return vim.v.shell_error == 0
+  job
+    :new({
+      command = "git",
+      args = args,
+      on_exit = function(_, return_val)
+        if return_val == 0 then
+          returnval = true
+        end
+      end,
+    })
+    :sync()
+  return returnval
 end
 
 local history = {}

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -61,7 +61,7 @@ local function update_status(state)
     local line = result[line_nr]
     if line:match("^[12u]%s[MTADRCU%s%.%?!][MTADRCU%s%.%?!]%s") or line:match("^[%?!#]%s") then
       table.insert(collection, line)
-    elseif prev_line and prev_line:match("2%sR") then
+    elseif prev_line and prev_line:match("^2%sR") then
       collection[#collection] = ("%s\t%s"):format(collection[#collection], line)
     end
     line_nr = line_nr + 1

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -61,7 +61,7 @@ local function update_status(state)
     local line = result[line_nr]
     if line:match("^[12u]%s[MTADRCU%s%.%?!][MTADRCU%s%.%?!]%s") or line:match("^[%?!#]%s") then
       table.insert(collection, line)
-    elseif prev_line and prev_line:match("2%sR%.%s") then
+    elseif prev_line and prev_line:match("2%sR") then
       collection[#collection] = ("%s\t%s"):format(collection[#collection], line)
     end
     line_nr = line_nr + 1


### PR DESCRIPTION
Multiple fixes for issues are contained in this PR:

- This PR fixes Issue #954 by changing:
   - the call to `vim.fn.system()` with `plenary.job`, and then testing the return value after the job finishes.
   - the call to `git_root_of_cwd()` with `plenary.job`, testing the return value and if in error defaults to `vim.fn.getcwd()` otherwise returns the directory from `git rev-parse --show-toplevel`

   On Windows, the `vim.fn.system()` was returning 127, instead of the expected 0, resulting in `false` whenever `is_inside_worktree()` is invoked. In turn, this always means the prompt for initializing the git repos is displayed for every Neogit operation. Plenary.job produces a 0 on success.

   Similarly, the call to `git_root_of_cwd()` kept returning the empty string "" (due to the non-zero success values) so `vim.fn.getcwd()` was always being called. The above change reduces the abstraction by making `opts.cwd`  have either the git toplevel directory or the current working directory whenever `git_root_of_cwd()` is invoked.

- This PR also fixes Issue #1256:
   - By matching on the beginning of the line and looking for `2 R` only then the regex matches the case for renamed files AND renamed and staged files. Since the file paths are matched properly they can be edited normally.