### PR TITLE
docs: update readme set verify_commit to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ neogit.setup {
   },
   commit_view = {
     kind = "vsplit",
-    verify_commit = os.execute("which gpg") == 0, -- Can be set to true or false, otherwise we try to find the binary
+    verify_commit = vim.fn.executable("gpg") == 1, -- Can be set to true or false, otherwise we try to find the binary
   },
   log_view = {
     kind = "tab",


### PR DESCRIPTION
Updates the default config to include the suppression of the stdout message.

https://github.com/NeogitOrg/neogit/blob/d51199a3552571a02b6d3d88b95acc4102ef2fd2/lua/neogit/config.lua#L222