### PR TITLE
Fix the ability to open a files from within neogit when cwd is set to a subdirectory or external location, fixes Issue #1140

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -581,9 +581,9 @@ local function git_root_of_cwd()
       on_exit = function(job_output, return_val)
         if return_val == 0 then
           -- Replace directory with the output of the git toplevel directory
-          gitdir = Path:new(job_output):absolute()
+          gitdir = Path:new(job_output:result()):absolute()
         else
-          logger.warn("[CLI]: ", job_output)
+          logger.warn("[CLI]: ", job_output:result())
         end
       end,
     })


### PR DESCRIPTION
This PR fixes the bug in Issue #1140.

The problem stems from the default directory being returned instead of the detected `.git`'s parent directory. This issue existed prior to PR #1281, but is now properly fixed in this PR.

Specifically, the text of plenary.job's `job_output` is in a table element retrieved by calling `result()` against the table.

With this PR the proper directory top-level is returned wherever `cwd` is defined, including sub-directories, and it also fixes the behavior with `cwd=%:p:h` so that opening files in the subdirectory returns the correct path and one can still open files above the defined `cwd` from within Neogit.