### PR TITLE
Editor mappings for `ZZ` and `ZQ`

### DIFF
--- a/lua/neogit/buffers/editor/init.lua
+++ b/lua/neogit/buffers/editor/init.lua
@@ -84,6 +84,11 @@ function M:open(kind)
     readonly = false,
     autocmds = {
       ["QuitPre"] = function() -- For :wq compatibility
+        if not aborted and amend_header then
+          self.buffer:set_lines(0, 0, false, amend_header)
+          self.buffer:write()
+        end
+
         if diff_view then
           diff_view:close()
           diff_view = nil
@@ -198,6 +203,7 @@ function M:open(kind)
           vim.cmd.stopinsert()
           if amend_header then
             buffer:set_lines(0, 0, false, amend_header)
+            amend_header = nil
           end
 
           buffer:write()
@@ -216,6 +222,7 @@ function M:open(kind)
           logger.debug("[EDITOR] Action N: Close")
           if amend_header then
             buffer:set_lines(0, 0, false, amend_header)
+            amend_header = nil
           end
 
           if buffer:get_option("modified") and not input.get_confirmation("Save changes?") then
@@ -229,6 +236,7 @@ function M:open(kind)
           logger.debug("[EDITOR] Action N: Submit")
           if amend_header then
             buffer:set_lines(0, 0, false, amend_header)
+            amend_header = nil
           end
 
           buffer:write()

--- a/lua/neogit/buffers/editor/init.lua
+++ b/lua/neogit/buffers/editor/init.lua
@@ -240,6 +240,22 @@ function M:open(kind)
           buffer:write()
           buffer:close(true)
         end,
+        ["ZZ"] = function(buffer)
+          logger.debug("[EDITOR] Action N: ZZ (submit)")
+          if amend_header then
+            buffer:set_lines(0, 0, false, amend_header)
+            amend_header = nil
+          end
+
+          buffer:write()
+          buffer:close(true)
+        end,
+        ["ZQ"] = function(buffer)
+          logger.debug("[EDITOR] Action N: ZQ (abort)")
+          aborted = true
+          buffer:write()
+          buffer:close(true)
+        end,
         [mapping["PrevMessage"]] = function(buffer)
           logger.debug("[EDITOR] Action N: PrevMessage")
           local message = current_message(buffer)

--- a/lua/neogit/buffers/rebase_editor/init.lua
+++ b/lua/neogit/buffers/rebase_editor/init.lua
@@ -174,6 +174,15 @@ function M:open(kind)
           buffer:write()
           buffer:close(true)
         end,
+        ["ZZ"] = function(buffer) -- Submit
+          buffer:write()
+          buffer:close(true)
+        end,
+        ["ZQ"] = function(buffer) -- abort
+          aborted = true
+          buffer:write()
+          buffer:close(true)
+        end,
         [mapping["Pick"]] = line_action("pick", comment_char),
         [mapping["Reword"]] = line_action("reword", comment_char),
         [mapping["Edit"]] = line_action("edit", comment_char),


### PR DESCRIPTION
Add ZZ and ZQ mappings to editor buffers to properly handle when a user closes the buffer this way. ZZ should commit the change, while ZQ should abort.

Fixes #1296