### PR TITLE
Fix console not responding to mappings

### DIFF
--- a/lua/neogit/buffers/process/init.lua
+++ b/lua/neogit/buffers/process/init.lua
@@ -90,7 +90,7 @@ function M:open()
       end,
     },
     mappings = {
-      n = {
+      t = {
         [status_maps["Close"]] = function()
           self:hide()
         end,


### PR DESCRIPTION
i.e. use terminal mode mappings

As shown in the image, the editor enters terminal mode when the console is opened, rendering quit keybinds nonfunctional.
![Image of the floating console, with the editor in terminal mode](https://github.com/NeogitOrg/neogit/assets/71049646/2cc80e49-048e-4d95-bc27-1e8c16d2af07)