### PR TITLE
Fix incorrect default option for commit_editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ neogit.setup {
     },
   },
   commit_editor = {
-    kind = "auto",
+    kind = "tab",
     show_staged_diff = true,
     -- Accepted values:
     -- "split" to show the staged diff below the commit editor


### PR DESCRIPTION
The README has the incorrect default option for `commit_editor`. The code shows that the default way of opening the default editor is in a new tab.