### PR TITLE
Fix typo in highlight name

### DIFF
--- a/lua/neogit/buffers/commit_view/ui.lua
+++ b/lua/neogit/buffers/commit_view/ui.lua
@@ -17,7 +17,7 @@ function M.OverviewFile(file)
     text.highlight("Number")(util.pad_left(file.changes, 5)),
     text("  "),
     text.highlight("NeogitDiffAdditions")(file.insertions),
-    text.highlight("NeogitDiffDeletetions")(file.deletions),
+    text.highlight("NeogitDiffDeletions")(file.deletions),
   }
 end
 


### PR DESCRIPTION
In commit view diff deletion highlighting wasn't working due to a typo
The correct highlight name defined in `lua/neogit/lib/hl.lua` is `NeogitDiffDeletions`