### PR TITLE
feat: add `vsplit_left`

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ neogit.setup {
     -- "split" to show the staged diff below the commit editor
     -- "vsplit" to show it to the right
     -- "split_above" Like :top split
+    -- "vsplit_left" like :vsplit, but open to the left
     -- "auto" "vsplit" if window would have 80 cols, otherwise "split"
     staged_diff_split_kind = "split"
   },

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -560,6 +560,7 @@ neogit.open({*opts})                                             *neogit.open()*
                     - "split"         like :below split
                     - "split_above"   like :top split
                     - "vsplit"        like :vsplit
+                    - "vsplit_left"   like :vsplit, but open to the left
                     - "floating" not-yet-implemented
 
                 • cwd (string) optional: Path to git repository.

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -599,14 +599,14 @@ function M.validate_config()
     if
       validate_type(val, name, "string")
       and not vim.tbl_contains(
-        { "split", "vsplit", "split_above", "tab", "floating", "replace", "auto" },
+        { "split", "vsplit", "split_above", "vsplit_left", "tab", "floating", "replace", "auto" },
         val
       )
     then
       err(
         name,
         string.format(
-          "Expected `%s` to be one of 'split', 'vsplit', 'split_above', 'tab', 'floating', 'replace' or 'auto', got '%s'",
+          "Expected `%s` to be one of 'split', 'vsplit', 'split_above', 'vsplit_left', tab', 'floating', 'replace' or 'auto', got '%s'",
           name,
           val
         )

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -269,6 +269,8 @@ function Buffer:show()
     win = api.nvim_open_win(self.handle, true, { split = "above" })
   elseif kind == "vsplit" then
     win = api.nvim_open_win(self.handle, true, { split = "right", vertical = true })
+  elseif kind == "vsplit_left" then
+    win = api.nvim_open_win(self.handle, true, { split = "left", vertical = true })
   elseif kind == "floating" then
     -- Creates the border window
     local vim_height = vim.o.lines


### PR DESCRIPTION
When I used *Neogit* a few days ago, the diff view was always on the left and the commit message editor on the right. This appears to have switched places.

This adds a `vsplit_left` option to open a new window to the left. In the case of the diff view, this can be set in `opts.commit_editor.staged_diff_split_kind` to open the diff view to the left. This restores the previous behavior.
