### PR TITLE
Remove unused keybind

### DIFF
--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -274,10 +274,6 @@ function M:open(kind)
         [status_maps["Toggle"]] = function()
           pcall(vim.cmd, "normal! za")
         end,
-        ["<space>"] = function()
-          -- require("neogit.lib.ui.debug")
-          -- self.buffer.ui:debug_layout()
-        end,
       },
     },
     render = function()


### PR DESCRIPTION
Space is super common to use as leader, so this was shadowing very important keymaps.