### PR TITLE
Ref view: refresh

### DIFF
--- a/lua/neogit/buffers/refs_view/init.lua
+++ b/lua/neogit/buffers/refs_view/init.lua
@@ -105,6 +105,7 @@ function M:open()
           p { commit = self.buffer.ui:get_commits_in_selection()[1] }
         end),
         [popups.mapping_for("PullPopup")] = popups.open("pull"),
+        [popups.mapping_for("FetchPopup")] = popups.open("fetch"),
         [popups.mapping_for("BisectPopup")] = popups.open("bisect", function(p)
           p { commits = self.buffer.ui:get_commits_in_selection() }
         end),
@@ -154,6 +155,7 @@ function M:open()
           p { commit = self.buffer.ui:get_commits_in_selection()[1] }
         end),
         [popups.mapping_for("PullPopup")] = popups.open("pull"),
+        [popups.mapping_for("FetchPopup")] = popups.open("fetch"),
         [popups.mapping_for("DiffPopup")] = popups.open("diff", function(p)
           local item = self.buffer.ui:get_commit_under_cursor()
           p {

--- a/lua/neogit/buffers/refs_view/init.lua
+++ b/lua/neogit/buffers/refs_view/init.lua
@@ -246,6 +246,9 @@ function M:open()
             end
           end
         end,
+        [status_maps["RefreshBuffer"]] = function()
+          self:dispatch_refresh({ update_refs = {} }, "n_refresh_buffer")
+        end,
       },
     },
     render = function()

--- a/lua/neogit/buffers/refs_view/ui.lua
+++ b/lua/neogit/buffers/refs_view/ui.lua
@@ -111,11 +111,22 @@ function M.Branches(branches, head)
   return { section(branches, { text.highlight("NeogitBranch")("Branches") }, head) }
 end
 
+local function sorted_names(remotes)
+  local remote_names = {}
+  for name, _ in pairs(remotes) do
+    table.insert(remote_names, name)
+  end
+  table.sort(remote_names)
+
+  return remote_names
+end
+
 function M.Remotes(remotes, head)
   local out = {}
   local max_len = util.max_length(vim.tbl_keys(remotes))
 
-  for name, branches in pairs(remotes) do
+  for _, name in pairs(sorted_names(remotes)) do
+    local branches = remotes[name]
     table.insert(
       out,
       section(branches, {

--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -609,7 +609,7 @@ end
 ---@param _self StatusBuffer
 M.n_show_refs = function(_self)
   return a.void(function()
-    require("neogit.buffers.refs_view").new(git.refs.list_parsed()):open()
+    require("neogit.buffers.refs_view").new(git.refs.list_parsed(), git.repo.git_root):open()
   end)
 end
 

--- a/lua/neogit/lib/git/refs.lua
+++ b/lua/neogit/lib/git/refs.lua
@@ -123,4 +123,10 @@ M.heads = util.memoize(function()
   return present
 end)
 
+function M.register(meta)
+  meta.update_refs = function(state)
+    state.refs = M.list_parsed()
+  end
+end
+
 return M

--- a/lua/neogit/lib/git/repository.lua
+++ b/lua/neogit/lib/git/repository.lua
@@ -16,6 +16,7 @@ local modules = {
   "merge",
   "bisect",
   "tag",
+  "refs",
 }
 
 ---@class NeogitRepoState
@@ -159,6 +160,7 @@ local function empty_state()
       finished = false,
       current = {},
     },
+    refs = {},
   }
 end
 

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -59,7 +59,8 @@ local function create_branch(popup, prompt, checkout)
     git.refs.heads()
   ))
 
-  local base_branch = FuzzyFinderBuffer.new(options):open_async { prompt_prefix = prompt }
+  local base_branch = FuzzyFinderBuffer.new(options)
+    :open_async { prompt_prefix = prompt, refocus_status = false }
   if not base_branch then
     return
   end
@@ -99,7 +100,7 @@ function M.checkout_branch_revision(popup)
       git.refs.heads()
     )
   )
-  local selected_branch = FuzzyFinderBuffer.new(options):open_async()
+  local selected_branch = FuzzyFinderBuffer.new(options):open_async { refocus_status = false }
   if not selected_branch then
     return
   end
@@ -120,6 +121,7 @@ function M.checkout_local_branch(popup)
 
   local target = FuzzyFinderBuffer.new(util.merge(local_branches, remote_branches)):open_async {
     prompt_prefix = "branch",
+    refocus_status = false,
   }
 
   if target then
@@ -151,7 +153,8 @@ function M.create_branch(popup)
 end
 
 function M.configure_branch()
-  local branch_name = FuzzyFinderBuffer.new(git.refs.list_local_branches()):open_async()
+  local branch_name = FuzzyFinderBuffer.new(git.refs.list_local_branches())
+    :open_async { refocus_status = false }
   if not branch_name then
     return
   end
@@ -160,7 +163,8 @@ function M.configure_branch()
 end
 
 function M.rename_branch()
-  local selected_branch = FuzzyFinderBuffer.new(git.refs.list_local_branches()):open_async()
+  local selected_branch = FuzzyFinderBuffer.new(git.refs.list_local_branches())
+    :open_async { refocus_status = false }
   if not selected_branch then
     return
   end
@@ -222,7 +226,7 @@ end
 
 function M.delete_branch(popup)
   local options = util.deduplicate(util.merge({ popup.state.env.ref_name }, git.refs.list_branches()))
-  local selected_branch = FuzzyFinderBuffer.new(options):open_async()
+  local selected_branch = FuzzyFinderBuffer.new(options):open_async { refocus_status = false }
   if not selected_branch then
     return
   end

--- a/lua/neogit/watcher.lua
+++ b/lua/neogit/watcher.lua
@@ -6,15 +6,15 @@ local util = require("neogit.lib.util")
 
 ---@class Watcher
 ---@field git_root string
----@field status_buffer StatusBuffer
+---@field buffer StatusBuffer
 ---@field running boolean
 ---@field fs_event_handler uv_fs_event_t
 local Watcher = {}
 Watcher.__index = Watcher
 
-function Watcher.new(status_buffer, root)
+function Watcher.new(buffer, root)
   local instance = {
-    status_buffer = status_buffer,
+    buffer = buffer,
     git_root = Path.new(root):joinpath(".git"):absolute(),
     running = false,
     fs_event_handler = assert(vim.loop.new_fs_event()),
@@ -54,7 +54,7 @@ local WATCH_IGNORE = {
 function Watcher:fs_event_callback()
   local refresh_debounced = util.debounce_trailing(200, function(info)
     logger.debug(info)
-    self.status_buffer:dispatch_refresh(nil, "watcher")
+    self.buffer:dispatch_refresh(nil, "watcher")
   end, 1)
 
   return function(err, filename, events)

--- a/lua/neogit/watcher.lua
+++ b/lua/neogit/watcher.lua
@@ -32,6 +32,8 @@ function Watcher:start()
     logger.debug("[WATCHER] Watching git dir: " .. self.git_root)
     self.fs_event_handler:start(self.git_root, {}, self:fs_event_callback())
   end
+
+  return self
 end
 
 function Watcher:stop()


### PR DESCRIPTION
I had a go at the refreshing of the ref view. This works as-is, but I'm wondering if you had any thoughts on the approach. Some details:
- I originally added the refs to the `git.repo.state` that the existing `git.repo:refresh` updated already, and was using that in some of the earlier commits, but I realised I could just refresh the refs state directly in the watcher callback which seems simpler for now, although there may be some drawbacks here. I also don't have a lock or anything like the main repo state refresh does, do you think it's worth adding one? I'm not super familiar with how async/concurrent the various functions are in neogit/nvim (yet :))
- The branch popup from the ref view kept taking me back to the status view, because the default options have `refocus_status` in - I've overridden this to false from the branch popup, but I guess there might be some situations where this is undesireable? It's quite nice to stay on the refs view if you're e.g. mass-deleting a load of local branches or something.
- If you have multiple remotes, I noticed sometimes they would change order so I added a sort in the UI rendering code to keep things stable here.
- I noticed that the setup of the Watcher in the status buffer wasn't actually getting assigned to the instance state [here](https://github.com/NeogitOrg/neogit/compare/master...actionshrimp:ref-view-refresh?expand=1#diff-b47379ff487cddc334f1b85eb050891d6f3ce3090579c7866bf9066815dfc829R204), as `:start()` returned `nil`, so this should hopefully help the status buffer clean up its watcher a bit better. 

Happy to tweak anything or split stuff out into separate PRs if that makes more sense!