### PR TITLE
Remove "call sync" interface for CLI

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -173,7 +173,7 @@ function M.open(opts)
   if not git.cli.is_inside_worktree(opts.cwd) then
     local input = require("neogit.lib.input")
     if input.get_permission(("Initialize repository in %s?"):format(opts.cwd)) then
-      git.init.create(opts.cwd, true)
+      git.init.create(opts.cwd)
     else
       notification.error("The current working directory is not a git repository")
       return

--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -48,12 +48,12 @@ local M = {
 ---@return CommitViewBuffer
 function M.new(commit_id, filter)
   local commit_info =
-    git.log.parse(git.cli.show.format("fuller").args(commit_id).call_sync({ trim = false }).stdout)[1]
+    git.log.parse(git.cli.show.format("fuller").args(commit_id).call({ trim = false }).stdout)[1]
 
   commit_info.commit_arg = commit_id
 
   local commit_overview =
-    parser.parse_commit_overview(git.cli.show.stat.oneline.args(commit_id).call_sync().stdout)
+    parser.parse_commit_overview(git.cli.show.stat.oneline.args(commit_id).call().stdout)
 
   local instance = {
     item_filter = filter,

--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -660,13 +660,13 @@ M.n_discard = function(self)
               input.get_choice("Discard conflict by taking...", { values = choices, default = #choices })
 
             if choice == "o" then
-              git.cli.checkout.ours.files(selection.item.absolute_path).call_sync()
+              git.cli.checkout.ours.files(selection.item.absolute_path).call()
               git.status.stage { selection.item.name }
             elseif choice == "t" then
-              git.cli.checkout.theirs.files(selection.item.absolute_path).call_sync()
+              git.cli.checkout.theirs.files(selection.item.absolute_path).call()
               git.status.stage { selection.item.name }
             elseif choice == "c" then
-              git.cli.checkout.merge.files(selection.item.absolute_path).call_sync()
+              git.cli.checkout.merge.files(selection.item.absolute_path).call()
               git.status.stage { selection.item.name }
             end
           end
@@ -691,13 +691,13 @@ M.n_discard = function(self)
               input.get_choice("Discard conflict by taking...", { values = choices, default = #choices })
 
             if choice == "o" then
-              git.cli.checkout.ours.files(selection.item.absolute_path).call_sync()
+              git.cli.checkout.ours.files(selection.item.absolute_path).call()
               git.status.stage { selection.item.name }
             elseif choice == "t" then
-              git.cli.checkout.theirs.files(selection.item.absolute_path).call_sync()
+              git.cli.checkout.theirs.files(selection.item.absolute_path).call()
               git.status.stage { selection.item.name }
             elseif choice == "c" then
-              git.cli.checkout.merge.files(selection.item.absolute_path).call_sync()
+              git.cli.checkout.merge.files(selection.item.absolute_path).call()
               git.status.stage { selection.item.name }
             end
           end

--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -92,9 +92,9 @@ local function get_local_diff_view(section_name, item_name, opts)
           table.insert(args, "HEAD")
         end
 
-        return git.cli.show.file(unpack(args)).call_sync({ trim = false }).stdout
+        return git.cli.show.file(unpack(args)).call({ trim = false }).stdout
       elseif kind == "working" then
-        local fdata = git.cli.show.file(path).call_sync({ trim = false }).stdout
+        local fdata = git.cli.show.file(path).call({ trim = false }).stdout
         return side == "left" and fdata
       end
     end,

--- a/lua/neogit/lib/git/bisect.lua
+++ b/lua/neogit/lib/git/bisect.lua
@@ -97,7 +97,7 @@ M.register = function(meta)
 
     local expected = vim.trim(git.repo:git_path("BISECT_EXPECTED_REV"):read())
     state.bisect.current =
-      git.log.parse(git.cli.show.format("fuller").args(expected).call_sync({ trim = false }).stdout)[1]
+      git.log.parse(git.cli.show.format("fuller").args(expected).call({ trim = false }).stdout)[1]
 
     state.bisect.finished = finished
   end

--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -41,7 +41,7 @@ function M.get_recent_local_branches()
   local valid_branches = M.get_local_branches()
 
   local branches = util.filter_map(
-    git.cli.reflog.show.format("%gs").date("relative").call_sync().stdout,
+    git.cli.reflog.show.format("%gs").date("relative").call().stdout,
     function(ref)
       local name = ref:match("^checkout: moving from .* to (.*)$")
       if vim.tbl_contains(valid_branches, name) then
@@ -54,7 +54,7 @@ function M.get_recent_local_branches()
 end
 
 function M.checkout(name, args)
-  git.cli.checkout.branch(name).arg_list(args or {}).call_sync()
+  git.cli.checkout.branch(name).arg_list(args or {}).call()
 
   if config.values.fetch_after_checkout then
     local pushRemote = M.pushRemote_ref(name)
@@ -78,16 +78,16 @@ function M.checkout(name, args)
 end
 
 function M.track(name, args)
-  git.cli.checkout.track(name).arg_list(args or {}).call_sync()
+  git.cli.checkout.track(name).arg_list(args or {}).call()
 end
 
 function M.get_local_branches(include_current)
-  local branches = git.cli.branch.list(config.values.sort_branches).call_sync().stdout
+  local branches = git.cli.branch.list(config.values.sort_branches).call().stdout
   return parse_branches(branches, include_current)
 end
 
 function M.get_remote_branches(include_current)
-  local branches = git.cli.branch.remotes.list(config.values.sort_branches).call_sync().stdout
+  local branches = git.cli.branch.remotes.list(config.values.sort_branches).call().stdout
   return parse_branches(branches, include_current)
 end
 
@@ -96,7 +96,7 @@ function M.get_all_branches(include_current)
 end
 
 function M.is_unmerged(branch, base)
-  return git.cli.cherry.arg_list({ base or M.base_branch(), branch }).call_sync().stdout[1] ~= nil
+  return git.cli.cherry.arg_list({ base or M.base_branch(), branch }).call().stdout[1] ~= nil
 end
 
 function M.base_branch()
@@ -118,7 +118,7 @@ end
 function M.exists(branch)
   local result = git.cli["rev-parse"].verify.quiet
     .args(string.format("refs/heads/%s", branch))
-    .call_sync { hidden = true, ignore_error = true }
+    .call { hidden = true, ignore_error = true }
 
   return result.code == 0
 end
@@ -149,10 +149,10 @@ function M.delete(name)
   if M.is_unmerged(name) then
     local message = ("'%s' contains unmerged commits! Are you sure you want to delete it?"):format(name)
     if input.get_permission(message) then
-      result = git.cli.branch.delete.force.name(name).call_sync()
+      result = git.cli.branch.delete.force.name(name).call()
     end
   else
-    result = git.cli.branch.delete.name(name).call_sync()
+    result = git.cli.branch.delete.name(name).call()
   end
 
   return result and result.code == 0 or false
@@ -165,7 +165,7 @@ function M.current()
   if head and head ~= "(detached)" then
     return head
   else
-    local branch_name = git.cli.branch.current.call_sync().stdout
+    local branch_name = git.cli.branch.current.call().stdout
     if #branch_name > 0 then
       return branch_name[1]
     end
@@ -177,7 +177,7 @@ end
 function M.current_full_name()
   local current = M.current()
   if current then
-    return git.cli["rev-parse"].symbolic_full_name.args(current).call_sync().stdout[1]
+    return git.cli["rev-parse"].symbolic_full_name.args(current).call().stdout[1]
   end
 end
 

--- a/lua/neogit/lib/git/cherry_pick.lua
+++ b/lua/neogit/lib/git/cherry_pick.lua
@@ -34,15 +34,15 @@ function M.apply(commits, args)
 end
 
 function M.continue()
-  git.cli["cherry-pick"].continue.call_sync()
+  git.cli["cherry-pick"].continue.call()
 end
 
 function M.skip()
-  git.cli["cherry-pick"].skip.call_sync()
+  git.cli["cherry-pick"].skip.call()
 end
 
 function M.abort()
-  git.cli["cherry-pick"].abort.call_sync()
+  git.cli["cherry-pick"].abort.call()
 end
 
 return M

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -1054,52 +1054,31 @@ local function new_builder(subcommand)
         end,
       }
 
-      local result = p:spawn_async(function()
-        -- Required since we need to do this before awaiting
-        if state.input then
-          logger.debug("Sending input:" .. vim.inspect(state.input))
-          -- Include EOT, otherwise git-apply will not work as expects the
-          -- stream to end
-          p:send(state.input .. "\04")
-          p:close_stdin()
+      local result
+      local function run_async()
+        result = p:spawn_async(function()
+          -- Required since we need to do this before awaiting
+          if state.input then
+            logger.debug("Sending input:" .. vim.inspect(state.input))
+            -- Include EOT, otherwise git-apply will not work as expects the
+            -- stream to end
+            p:send(state.input .. "\04")
+            p:close_stdin()
+          end
+        end)
+      end
+
+      local ok, _ = pcall(run_async)
+      if not ok then
+        logger.debug("Running command async failed - awaiting instead")
+        if not p:spawn() then
+          error("Failed to run command")
+          return nil
         end
-      end)
 
-      assert(result, "Command did not complete")
-
-      handle_new_cmd({
-        cmd = table.concat(p.cmd, " "),
-        stdout = result.stdout,
-        stderr = result.stderr,
-        code = result.code,
-        time = result.time,
-      }, state.show_popup, state.hide_text, opts.hidden)
-
-      if opts.trim then
-        return result:trim()
-      else
-        return result
-      end
-    end,
-    call_sync = function(options)
-      local opts = vim.tbl_extend(
-        "keep",
-        (options or {}),
-        { verbose = false, ignore_error = not state.show_popup, hidden = false, trim = true }
-      )
-
-      local p = to_process {
-        on_error = function(_res)
-          return not opts.ignore_error
-        end,
-      }
-
-      if not p:spawn() then
-        error("Failed to run command")
-        return nil
+        result = p:wait()
       end
 
-      local result = p:wait()
       assert(result, "Command did not complete")
 
       handle_new_cmd({

--- a/lua/neogit/lib/git/config.lua
+++ b/lua/neogit/lib/git/config.lua
@@ -83,7 +83,7 @@ local function build_config()
   local result = {}
 
   local out = vim.split(
-    table.concat(git.cli.config.list.null._local.call_sync({ hidden = true }).stdout_raw, "\0"),
+    table.concat(git.cli.config.list.null._local.call({ hidden = true }).stdout_raw, "\0"),
     "\n"
   )
   for _, option in ipairs(out) do
@@ -114,7 +114,7 @@ end
 
 ---@return ConfigEntry
 function M.get_global(key)
-  local result = git.cli.config.get(key).call_sync({ ignore_error = true }).stdout[1]
+  local result = git.cli.config.get(key).call({ ignore_error = true }).stdout[1]
   return ConfigEntry.new(key, result, "global")
 end
 
@@ -135,7 +135,7 @@ function M.set(key, value)
   if not value or value == "" then
     M.unset(key)
   else
-    git.cli.config.set(key, value).call_sync()
+    git.cli.config.set(key, value).call()
   end
 end
 
@@ -146,7 +146,7 @@ function M.unset(key)
   end
 
   cache_key = nil
-  git.cli.config.unset(key).call_sync()
+  git.cli.config.unset(key).call()
 end
 
 return M

--- a/lua/neogit/lib/git/config.lua
+++ b/lua/neogit/lib/git/config.lua
@@ -82,10 +82,8 @@ end
 local function build_config()
   local result = {}
 
-  local out = vim.split(
-    table.concat(git.cli.config.list.null._local.call({ hidden = true }).stdout_raw, "\0"),
-    "\n"
-  )
+  local out =
+    vim.split(table.concat(git.cli.config.list.null._local.call({ hidden = true }).stdout_raw, "\0"), "\n")
   for _, option in ipairs(out) do
     local key, value = unpack(vim.split(option, "\0"))
 

--- a/lua/neogit/lib/git/diff.lua
+++ b/lua/neogit/lib/git/diff.lua
@@ -273,7 +273,7 @@ end
 return {
   parse = parse_diff,
   staged_stats = function()
-    local raw = git.cli.diff.no_ext_diff.cached.stat.call_sync({ hidden = true }).stdout
+    local raw = git.cli.diff.no_ext_diff.cached.stat.call({ hidden = true }).stdout
     local files = {}
     local summary
 

--- a/lua/neogit/lib/git/files.lua
+++ b/lua/neogit/lib/git/files.lua
@@ -4,21 +4,21 @@ local git = require("neogit.lib.git")
 local M = {}
 
 function M.all()
-  return git.cli["ls-files"].full_name.deleted.modified.exclude_standard.deduplicate.call_sync({
+  return git.cli["ls-files"].full_name.deleted.modified.exclude_standard.deduplicate.call({
     hidden = true,
   }).stdout
 end
 
 function M.untracked()
-  return git.cli["ls-files"].others.exclude_standard.call_sync({ hidden = true }).stdout
+  return git.cli["ls-files"].others.exclude_standard.call({ hidden = true }).stdout
 end
 
 function M.all_tree()
-  return git.cli["ls-tree"].full_tree.name_only.recursive.args("HEAD").call_sync({ hidden = true }).stdout
+  return git.cli["ls-tree"].full_tree.name_only.recursive.args("HEAD").call({ hidden = true }).stdout
 end
 
 function M.diff(commit)
-  return git.cli.diff.name_only.args(commit .. "...").call_sync({ hidden = true }).stdout
+  return git.cli.diff.name_only.args(commit .. "...").call({ hidden = true }).stdout
 end
 
 function M.relpath_from_repository(path)

--- a/lua/neogit/lib/git/init.lua
+++ b/lua/neogit/lib/git/init.lua
@@ -5,14 +5,8 @@ local input = require("neogit.lib.input")
 ---@class NeogitGitInit
 local M = {}
 
-M.create = function(directory, sync)
-  sync = sync or false
-
-  if sync then
-    git.cli.init.args(directory).call()
-  else
-    git.cli.init.args(directory).call()
-  end
+M.create = function(directory)
+  git.cli.init.args(directory).call()
 end
 
 -- TODO Use path input

--- a/lua/neogit/lib/git/init.lua
+++ b/lua/neogit/lib/git/init.lua
@@ -9,7 +9,7 @@ M.create = function(directory, sync)
   sync = sync or false
 
   if sync then
-    git.cli.init.args(directory).call_sync()
+    git.cli.init.args(directory).call()
   else
     git.cli.init.args(directory).call()
   end

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -381,7 +381,7 @@ end)
 function M.is_ancestor(ancestor, descendant)
   return git.cli["merge-base"].is_ancestor
     .args(ancestor, descendant)
-    .call_sync({ ignore_error = true, hidden = true }).code == 0
+    .call({ ignore_error = true, hidden = true }).code == 0
 end
 
 ---Finds parent commit of a commit. If no parent exists, will return nil
@@ -442,7 +442,7 @@ end
 ---@param commit string Hash of commit
 ---@return string The stderr output of the command
 function M.verify_commit(commit)
-  return git.cli["verify-commit"].args(commit).call_sync({ ignore_error = true }).stderr
+  return git.cli["verify-commit"].args(commit).call({ ignore_error = true }).stderr
 end
 
 ---@class CommitBranchInfo
@@ -517,7 +517,7 @@ function M.reflog_message(skip)
     .format("%B")
     .max_count(1)
     .args("--reflog", "--no-merges", "--skip=" .. tostring(skip))
-    .call_sync({ ignore_error = true }).stdout
+    .call({ ignore_error = true }).stdout
 end
 
 M.abbreviated_size = util.memoize(function()

--- a/lua/neogit/lib/git/remote.lua
+++ b/lua/neogit/lib/git/remote.lua
@@ -26,7 +26,7 @@ function M.add(name, url, args)
 end
 
 function M.rename(from, to)
-  local result = git.cli.remote.rename.arg_list({ from, to }).call_sync()
+  local result = git.cli.remote.rename.arg_list({ from, to }).call()
   if result.code == 0 then
     cleanup_push_variables(from, to)
   end
@@ -35,7 +35,7 @@ function M.rename(from, to)
 end
 
 function M.remove(name)
-  local result = git.cli.remote.rm.args(name).call_sync()
+  local result = git.cli.remote.rm.args(name).call()
   if result.code == 0 then
     cleanup_push_variables(name)
   end
@@ -48,7 +48,7 @@ function M.prune(name)
 end
 
 M.list = util.memoize(function()
-  return git.cli.remote.call_sync({ hidden = false }).stdout
+  return git.cli.remote.call({ hidden = false }).stdout
 end)
 
 function M.get_url(name)

--- a/lua/neogit/lib/git/reset.lua
+++ b/lua/neogit/lib/git/reset.lua
@@ -80,7 +80,7 @@ end
 -- end
 
 function M.file(commit, files)
-  local result = git.cli.checkout.rev(commit).files(unpack(files)).call_sync()
+  local result = git.cli.checkout.rev(commit).files(unpack(files)).call()
   if result.code ~= 0 then
     notification.error("Reset Failed")
   else

--- a/lua/neogit/lib/git/rev_parse.lua
+++ b/lua/neogit/lib/git/rev_parse.lua
@@ -21,7 +21,7 @@ end, { timeout = math.huge })
 ---@return string
 ---@async
 function M.oid(rev)
-  return git.cli["rev-parse"].args(rev).call_sync({ hidden = true, ignore_error = true }).stdout[1]
+  return git.cli["rev-parse"].args(rev).call({ hidden = true, ignore_error = true }).stdout[1]
 end
 
 return M

--- a/lua/neogit/lib/git/revert.lua
+++ b/lua/neogit/lib/git/revert.lua
@@ -9,15 +9,15 @@ function M.commits(commits, args)
 end
 
 function M.continue()
-  git.cli.revert.continue.call_sync()
+  git.cli.revert.continue.call()
 end
 
 function M.skip()
-  git.cli.revert.skip.call_sync()
+  git.cli.revert.skip.call()
 end
 
 function M.abort()
-  git.cli.revert.abort.call_sync()
+  git.cli.revert.abort.call()
 end
 
 return M

--- a/lua/neogit/lib/git/worktree.lua
+++ b/lua/neogit/lib/git/worktree.lua
@@ -10,7 +10,7 @@ local M = {}
 ---@param path string absolute path
 ---@return boolean
 function M.add(ref, path, params)
-  local result = git.cli.worktree.add.arg_list(params or {}).args(path, ref).call_sync()
+  local result = git.cli.worktree.add.arg_list(params or {}).args(path, ref).call()
   return result.code == 0
 end
 

--- a/lua/neogit/lib/ui/init.lua
+++ b/lua/neogit/lib/ui/init.lua
@@ -176,7 +176,7 @@ function Ui:item_hunks(item, first_line, last_line, partial)
   local hunks = {}
 
   -- TODO: Move this to lib.git.diff
-  -- local diff = require("neogit.lib.git").cli.diff.check.call_sync { hidden = true, ignore_error = true }
+  -- local diff = require("neogit.lib.git").cli.diff.check.call { hidden = true, ignore_error = true }
   -- local conflict_markers = {}
   -- if diff.code == 2 then
   --   for _, out in ipairs(diff.stdout) do

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -104,7 +104,7 @@ function M.checkout_branch_revision(popup)
     return
   end
 
-  git.cli.checkout.branch(selected_branch).arg_list(popup:get_arguments()).call_sync()
+  git.cli.checkout.branch(selected_branch).arg_list(popup:get_arguments()).call()
   fire_branch_event("NeogitBranchCheckout", { branch_name = selected_branch })
 end
 
@@ -213,7 +213,7 @@ function M.reset_branch(popup)
   end
 
   -- Reset the current branch to the desired state & update reflog
-  git.cli.reset.hard.args(to).call_sync()
+  git.cli.reset.hard.args(to).call()
   git.log.update_ref(git.branch.current_full_name(), to)
 
   notification.info(string.format("Reset '%s' to '%s'", current, to))
@@ -235,7 +235,7 @@ function M.delete_branch(popup)
     and branch_name
     and input.get_permission(("Delete remote branch '%s/%s'?"):format(remote, branch_name))
   then
-    success = git.cli.push.remote(remote).delete.to(branch_name).call_sync().code == 0
+    success = git.cli.push.remote(remote).delete.to(branch_name).call().code == 0
   elseif not remote and branch_name == git.branch.current() then
     local choices = {
       "&detach HEAD and delete",
@@ -253,16 +253,16 @@ function M.delete_branch(popup)
     )
 
     if choice == "d" then
-      git.cli.checkout.detach.call_sync()
+      git.cli.checkout.detach.call()
     elseif choice == "c" then
-      git.cli.checkout.branch(upstream).call_sync()
+      git.cli.checkout.branch(upstream).call()
     else
       return
     end
 
     success = git.branch.delete(branch_name)
     if not success then -- Reset HEAD if unsuccessful
-      git.cli.checkout.branch(branch_name).call_sync()
+      git.cli.checkout.branch(branch_name).call()
     end
   elseif not remote and branch_name then
     success = git.branch.delete(branch_name)

--- a/lua/neogit/popups/rebase/actions.lua
+++ b/lua/neogit/popups/rebase/actions.lua
@@ -178,7 +178,7 @@ end
 -- TODO: Extract to rebase lib?
 function M.abort()
   if input.get_permission("Abort rebase?") then
-    git.cli.rebase.abort.call_sync()
+    git.cli.rebase.abort.call()
   end
 end
 


### PR DESCRIPTION
Just try to run async, and if that fails (usually with "cannot yield across c-call boundary") then fallback to running the command and awaiting the result.

Hopefully this should remove some confusion around which interface to use, and will prefer async at all times unless that doesn't work.

Hopefully no side effects.


Could probably be refactored to contain this logic in the process class.