### PR TITLE
Updated GPG integration docs

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -245,6 +245,12 @@ to properly integrate the password authentication with Neogit:
   Note: If you are not using Homebrew you may need to change the path for
         `pinentry-program
 
+  Note: The location of these config files may not be in "~/.gnupg/" depending
+        on your system configuration. To find where they should be placed run
+        "gpgconf --list-dirs" and place them in the path which follows the
+        line starting "homedir:". For example this could be
+        "$XDG_DATA_HOME/gnupg/"
+
 ==============================================================================
 Mappings                                                 *neogit_setup_mappings*
 


### PR DESCRIPTION
I was having difficulties getting GPG integration to work on my system as explained in #1245. The issue ended up being that my GPG conf files were placed in the incorrect directory so the config wasn't being picked up. I thought I should add the command I used to work out what directory I needed to use in a note within the docs to help people who may come across this issue in the future.