### PR TITLE
Add config feature 'initial_branch_name'

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ neogit.setup {
   -- Flag description: https://git-scm.com/docs/git-branch#Documentation/git-branch.txt---sortltkeygt
   -- Sorting keys: https://git-scm.com/docs/git-for-each-ref#_options
   sort_branches = "-committerdate",
+  -- Default for new branch name prompts
+  initial_branch_name = "",
   -- Change the default way of opening neogit
   kind = "tab",
   -- Disable line numbers and relative line numbers

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -113,6 +113,7 @@ TODO: Detail what these do
     fetch_after_checkout = false,
     auto_refresh = true,
     sort_branches = "-committerdate",
+    initial_branch_name = "",
     kind = "tab",
     disable_line_numbers = true,
     -- The time after which an output console is shown for slow running commands

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -303,6 +303,7 @@ end
 ---@field use_per_project_settings? boolean Scope persisted settings on a per-project basis
 ---@field remember_settings? boolean Whether neogit should persist flags from popups, e.g. git push flags
 ---@field sort_branches? string Value used for `--sort` for the `git branch` command
+---@field initial_branch_name? string Default for new branch name prompts
 ---@field kind? WindowKind The default type of window neogit should open in
 ---@field disable_line_numbers? boolean Whether to disable line numbers
 ---@field disable_relative_line_numbers? boolean Whether to disable line numbers
@@ -359,6 +360,7 @@ function M.get_default_values()
     fetch_after_checkout = false,
     sort_branches = "-committerdate",
     kind = "tab",
+    initial_branch_name = "",
     disable_line_numbers = true,
     disable_relative_line_numbers = true,
     -- The time after which an output console is shown for slow running commands
@@ -1087,6 +1089,7 @@ function M.validate_config()
     validate_type(config.use_per_project_settings, "use_per_project_settings", "boolean")
     validate_type(config.remember_settings, "remember_settings", "boolean")
     validate_type(config.sort_branches, "sort_branches", "string")
+    validate_type(config.initial_branch_name, "initial_branch_name", "string")
     validate_type(config.notification_icon, "notification_icon", "string")
     validate_type(config.console_timeout, "console_timeout", "number")
     validate_kind(config.kind, "kind")

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -43,14 +43,18 @@ local function checkout_branch(target, args)
   end
 end
 
+local function get_branch_name_user_input(prompt, default)
+  default = default or config.values.initial_branch_name
+  return input.get_user_input(prompt, { strip_spaces = true, default = default })
+end
+
 local function spin_off_branch(checkout)
   if git.status.is_dirty() and not checkout then
     notification.info("Staying on HEAD due to uncommitted changes")
     checkout = true
   end
 
-  local name =
-    input.get_user_input(("%s branch"):format(checkout and "Spin-off" or "Spin-out"), { strip_spaces = true })
+  local name = get_branch_name_user_input(("%s branch"):format(checkout and "Spin-off" or "Spin-out"))
   if not name then
     return
   end
@@ -215,7 +219,7 @@ function M.rename_branch()
     return
   end
 
-  local new_name = input.get_user_input(("Rename '%s' to"):format(selected_branch), { strip_spaces = true })
+  local new_name = get_branch_name_user_input(("Rename '%s' to"):format(selected_branch))
   if not new_name then
     return
   end

--- a/tests/specs/neogit/config_spec.lua
+++ b/tests/specs/neogit/config_spec.lua
@@ -56,6 +56,11 @@ describe("Neogit config", function()
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
       end)
 
+      it("should return invalid when initial_branch_name isn't a string", function()
+        config.values.initial_branch_name = false
+        assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
+      end)
+
       it("should return invalid when kind isn't a string", function()
         config.values.kind = true
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)


### PR DESCRIPTION
This config feature allows users to specify an initial branch name that will be used as a `get_user_input` default when Neogit asks for a name for a new branch.

This is useful when working in teams with a branch naming convention. For example, teams may choose to prefix branches with a GitHub username. In that case, configuring Neogit with:

```
initial_branch_name = "myname/"
```

...will result in the popup being prepopulated with `myname/`, after which I can specify the branch name.