### PR TITLE
feat: show all untracked files in status buffer

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -129,6 +129,7 @@ local configurations = {
     },
     options = {
       porcelain = "--porcelain",
+      untracked_files = "--untracked-files",
     },
   },
 

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -62,7 +62,7 @@ local function update_status(state, filter)
   state.untracked.items = {}
   state.unstaged.items = {}
 
-  local result = git.cli.status.null_separated.porcelain(2).call { hidden = true }
+  local result = git.cli.status.null_separated.porcelain(2).untracked_files("all").call { hidden = true }
   result = vim.split(result.stdout_raw[1], "\n")
   result = util.collect(result, function(line, collection)
     if line == "" then


### PR DESCRIPTION
This enables showing **all** unstaged files in the status buffer
instead of just the directories containing them.

While this could theoretically be enabled by setting `git config status.showUntrackedFiles all`,
I think showing all the unstaged files would be a pretty good default for neogit, especially when staging files.
