### PR TITLE
Handle removing ANSI escape codes. 

### DIFF
--- a/lua/neogit/lib/git/config.lua
+++ b/lua/neogit/lib/git/config.lua
@@ -82,8 +82,10 @@ end
 local function build_config()
   local result = {}
 
-  local out =
-    vim.split(table.concat(git.cli.config.list.null._local.call({ hidden = true }).stdout, "\0"), "\n")
+  local out = vim.split(
+    table.concat(git.cli.config.list.null._local.call({ hidden = true, remove_ansi = false }).stdout, "\0"),
+    "\n"
+  )
   for _, option in ipairs(out) do
     local key, value = unpack(vim.split(option, "\0"))
 

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -292,7 +292,7 @@ M.graph = util.memoize(function(options, files, color)
     .format("%x1E%H%x00").graph.color
     .arg_list(options)
     .files(unpack(files))
-    .call({ ignore_error = true, hidden = true }).stdout
+    .call({ ignore_error = true, hidden = true, remove_ansi = false }).stdout
 
   return util.filter_map(result, function(line)
     return require("neogit.lib.ansi").parse(util.trim(line), { recolor = not color })

--- a/lua/neogit/lib/git/status.lua
+++ b/lua/neogit/lib/git/status.lua
@@ -62,7 +62,7 @@ local function update_status(state, filter)
   state.untracked.items = {}
   state.unstaged.items = {}
 
-  local result = git.cli.status.null_separated.porcelain(2).call { hidden = true }
+  local result = git.cli.status.null_separated.porcelain(2).call { hidden = true, remove_ansi = false }
   result = vim.split(result.stdout[1] or "", "\n")
   result = util.collect(result, function(line, collection)
     if line == "" then

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -579,4 +579,17 @@ function M.throttle_by_id(fn, schedule)
     end
   end
 end
+
+-- from: https://stackoverflow.com/questions/48948630/lua-ansi-escapes-pattern
+local pattern_1 = "[\27\155][][()#;?%d]*[A-PRZcf-ntqry=><~]"
+local pattern_2 = "[\r\n\04\08]"
+local BLANK = ""
+local gsub = string.gsub
+
+function M.remove_ansi_escape_codes(s)
+  s, _ = gsub(s, pattern_1, BLANK)
+  s, _ = gsub(s, pattern_2, BLANK)
+  return s
+end
+
 return M

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -3,6 +3,7 @@ local notification = require("neogit.lib.notification")
 
 local config = require("neogit.config")
 local logger = require("neogit.logger")
+local util = require("neogit.lib.util")
 
 local command_mask =
   vim.pesc(" --no-pager --literal-pathspecs --no-optional-locks -c core.preloadindex=true -c color.ui=always")
@@ -42,16 +43,31 @@ local ProcessResult = {}
 ---Removes empty lines from output
 ---@return ProcessResult
 function ProcessResult:trim()
+  local BLANK = ""
   self.stdout = vim.tbl_filter(function(v)
-    return v ~= ""
+    return v ~= BLANK
   end, self.stdout)
 
   self.stderr = vim.tbl_filter(function(v)
-    return v ~= ""
+    return v ~= BLANK
   end, self.stderr)
 
   return self
 end
+
+function ProcessResult:remove_ansi()
+  local remove_ansi_escape_codes = util.remove_ansi_escape_codes
+  self.stdout = vim.tbl_map(function(v)
+    return remove_ansi_escape_codes(v)
+  end, self.stdout)
+
+  self.stderr = vim.tbl_map(function(v)
+    return remove_ansi_escape_codes(v)
+  end, self.stderr)
+
+  return self
+end
+
 ProcessResult.__index = ProcessResult
 
 ---@param process Process


### PR DESCRIPTION
Some shells seem to add more than others? It's unclear why, but it causes issues for some people.

The reason it was removed is because it is a bit slow with large input.

https://github.com/NeogitOrg/neogit/issues/1389