### PR TITLE
fix(help): correctly handle if `keymap` is `"<nop>"`

### DIFF
--- a/lua/neogit/popups/help/actions.lua
+++ b/lua/neogit/popups/help/actions.lua
@@ -16,7 +16,7 @@ local function present(commands)
     end
 
     local keymap = status_mappings[cmd] or popup_mappings[cmd]
-    if keymap and #keymap > 0 then
+    if type(keymap) == "table" and next(keymap) then
       return { { name = name, keys = keymap, cmp = table.concat(keymap):lower(), fn = fn } }
     else
       return { { name = name, keys = {}, cmp = "", fn = fn } }


### PR DESCRIPTION
Currently the help pop up is broken because keymaps can be equal to `"<nop>"`. This correctly verifies that the keymap is a table before adding it so that it skips `nop`s.

Even with a completely base, minimal installation, running `?` doesn't work at all. This fixes that