### PR TITLE
fix: do not use `normal ex` cmd for process refresh

### DIFF
--- a/lua/neogit/buffers/process/init.lua
+++ b/lua/neogit/buffers/process/init.lua
@@ -63,7 +63,7 @@ end
 
 function M:refresh()
   self.buffer:chan_send(self.content)
-  self.buffer:call(vim.cmd.normal, "G")
+  self.buffer:move_cursor(self.buffer:line_count())
 end
 
 function M:append(data)

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -469,6 +469,10 @@ function Buffer:set_decorations(namespace, opts)
   end
 end
 
+function Buffer:line_count()
+  return api.nvim_buf_line_count(self.handle)
+end
+
 function Buffer:set_header(text)
   -- Create a blank line at the top of the buffer so our floating window doesn't
   -- hide any content


### PR DESCRIPTION
As a heads up, I'm unsure if there are issues open (or opened previously) that related to this. I, at least, couldn't find any.

Copied from the body of the commit:

> Problem: Currently `normal ex` commands don't work in terminal mode in Neovim. Currently the `ProcessBuffer` in Neogit displays long running git commands by default in a terminal buffer and sets the cursor to the bottom of the buffer on refresh via `normal G` which causes an error.
> 
> See https://github.com/neovim/neovim/issues/4895 which is the tracking issue in Neovim for `normal ex` commands in terminal mode.
> 
> Solution: Use Neovim's API to explicitly set the cursor position within the `ProcessBuffer`, avoiding invoking an `normal ex` 

Using the following `pre-commit` git hook:
```bash
local count=0
while :; do
	count="$((count + 1))"
	printf "COUNT: %d\n" "${count}"
	sleep 1
done
```
I was able to test this issue. See the before and after below.

### Before
[before-fix.webm](https://github.com/NeogitOrg/neogit/assets/58627896/8f3af11c-b5d5-4d03-82fd-e78d32a2e706)

### After
[after-fix.webm](https://github.com/NeogitOrg/neogit/assets/58627896/cb9280d6-cfd2-4f29-b33b-60b1ccb7aa27)

Let me know if any further changes are desired 🙂 