### PR TITLE
Address race condition when opening file

### DIFF
--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -54,7 +54,7 @@ local function translate_cursor_location(self, item)
 end
 
 local function open(type, path, cursor)
-  local command = ("silent! %s %s | %s | norm! zz"):format(
+  local command = ("silent! %s %s | %s | redraw! | norm! zz"):format(
     type,
     fn.fnameescape(path),
     cursor and cursor[1] or "1"
@@ -1098,7 +1098,7 @@ M.n_goto_file = function(self)
     if item and item.absolute_path then
       local cursor = translate_cursor_location(self, item)
       self:close()
-      open("edit", item.absolute_path, cursor)
+      vim.schedule_wrap(open)("edit", item.absolute_path, cursor)
       return
     end
 


### PR DESCRIPTION
Use schedule_wrap on the opening command to help prevent a race condition where the edit command is run _before_ the neogit buffer is closed, resulting in the file being opened in the neogit window... then closed.