### PR TITLE
Fix restoring scroll when unfolding in status view

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -72,8 +72,6 @@ function M.setup(opts)
   M.config = config
   M.notification = require("neogit.lib.notification")
 
-  M.notification.info("You are using the `nightly` branch for neogit.\nThis branch will no longer be receiving updates - use `master` to stay up-to-date.")
-
   config.setup(opts)
   hl.setup()
   signs.setup()

--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -72,6 +72,8 @@ function M.setup(opts)
   M.config = config
   M.notification = require("neogit.lib.notification")
 
+  M.notification.info("You are using the `nightly` branch for neogit.\nThis branch will no longer be receiving updates - use `master` to stay up-to-date.")
+
   config.setup(opts)
   hl.setup()
   signs.setup()

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -172,6 +172,22 @@ function Buffer:move_cursor(line)
   pcall(api.nvim_win_set_cursor, self.win_handle, position)
 end
 
+---@param line nil|number|number[]
+function Buffer:move_top_line(line)
+  if not line then
+    return
+  end
+
+  local position = { line, 0 }
+
+  if type(line) == "table" then
+    position = line
+  end
+
+  -- pcall used in case the line is out of bounds
+  pcall(vim.api.nvim_command, "normal! " .. position[1] .. "zt")
+end
+
 function Buffer:cursor_line()
   return api.nvim_win_get_cursor(0)[1]
 end

--- a/spec/buffers/log_buffer_spec.rb
+++ b/spec/buffers/log_buffer_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Log Buffer", :git, :nvim do
   end
 
   it "can open CommitView" do
-    nvim.keys("ll<up><enter>")
+    nvim.keys("ll<up><down><enter>")
     expect(nvim.errors).to be_empty
     expect(nvim.filetype).to eq("NeogitCommitView")
   end


### PR DESCRIPTION
- [x] Based off `nightly` branch

The current `Ui:update` function only restores the cursor, but not the "scroll", i.e. the top line, as noted in https://github.com/NeogitOrg/neogit/issues/841#issuecomment-2237724913.

This PR addresses that issue by first restoring the proper top line, taking `scrolloff` and folds into account, then finally restoring cursor. This prevents jumping when folding in the status view.

Here's a video demonstrating before and after:
https://github.com/user-attachments/assets/cefb50a2-107c-4718-a419-417fe1b19aa0
(I'm jumping around a bit in the after one with C-D and C-U, but rest assured the folding restores the scroll like it should)

Now, an alternative to this solution would be to look into a way to update the Ui _without resetting cursor position_ completely. That could perhaps be done by updating the buffer with the new lines instead of first clearing it, and might even be more performant. But I don't know enough about the internals to make this call.


