### PR TITLE
Address performance regression

### DIFF
--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -249,7 +249,6 @@ function Process:spawn(cb)
 
   local stdout_on_line = function(line)
     insert(res.stdout, line)
-    insert(res.output, line)
     self.buffer:append(line)
   end
 
@@ -257,7 +256,6 @@ function Process:spawn(cb)
 
   local stderr_on_line = function(line)
     insert(res.stderr, line)
-    insert(res.output, line)
     self.buffer:append(line)
   end
 


### PR DESCRIPTION
When loading very very large diffs, appending to the output buffer would perform way way way too much string allocations/rehashing.

To address this, we can stop appending output to this buffer after 300 lines. It may be worth pursuing not appending anything to this buffer at all unless it's a PTY process, but that can be looked into later.