### PR TITLE
Fix regression when closing last window

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -216,10 +216,7 @@ function Buffer:close(force)
     local winnr = fn.bufwinnr(self.handle)
     if winnr ~= -1 then
       local winid = fn.win_getid(winnr)
-      local ok, _ = pcall(vim.schedule_wrap(api.nvim_win_close), winid, force)
-      if not ok then
-        vim.schedule_wrap(vim.cmd)("b#")
-      end
+      vim.schedule_wrap(util.safe_win_close)(winid, force)
     else
       vim.schedule_wrap(api.nvim_buf_delete)(self.handle, { force = force })
     end
@@ -241,7 +238,7 @@ function Buffer:hide()
       self.old_buf = nil
     end
   else
-    api.nvim_win_close(0, true)
+    vim.schedule_wrap(util.safe_win_close)(0, true)
   end
 end
 

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -238,7 +238,7 @@ function Buffer:hide()
       self.old_buf = nil
     end
   else
-    vim.schedule_wrap(util.safe_win_close)(0, true)
+    util.safe_win_close(0, true)
   end
 end
 

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -592,4 +592,15 @@ function M.remove_ansi_escape_codes(s)
   return s
 end
 
+--- Safely close a window
+---@param winid integer
+---@param force boolean
+function M.safe_win_close(winid, force)
+  local ok, _ = pcall(vim.api.nvim_win_close, winid, force)
+
+  if not ok then
+    vim.cmd("b#")
+  end
+end
+
 return M


### PR DESCRIPTION
This PR fixes a regression introduced by e69c1b01b4cf0803cad5d7e49430af16760be55c, which wraps the closing by `schedule_wrap`. However, by wrapping it, `pcall` will never catch the error by `nvim_win_close`, causing a regression.

Adds a utility to safely close the window, since multiple places called `nvim_win_close` without handling the potential failure.

Fixes #1423.

One concern is the possibility that `nvim_buf_delete` in `Buffer:hide` could cause a similar error, but might be premature to add safety to this.