### PR TITLE
Fix: actually show/focus buffers when existing window

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -256,6 +256,7 @@ function Buffer:show()
 
   -- Already visible
   if #windows > 0 then
+    vim.api.nvim_set_current_win(windows[1])
     return windows[1]
   end
 


### PR DESCRIPTION
The show method was not working correctly for existing windows, while for buffers that are not already visible it would actually make sure to show the buffer by creating the layout according to the `kind` value. Fixes: https://github.com/NeogitOrg/neogit/issues/1373
