### PR TITLE
set preview_buffer.kind in default config as documented in README and neogit.txt

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -400,7 +400,7 @@ function M.get_default_values()
       kind = "auto",
     },
     preview_buffer = {
-      kind = "floating",
+      kind = "split",
     },
     popup = {
       kind = "split",


### PR DESCRIPTION
preview_buffer.kind is documented in [README.md](https://github.com/NeogitOrg/neogit/blob/6af8fc6b03210d0ac99398f8eff27c5be7b2ba8a/README.md?plain=1#L195-L197) and [doc/neogit.txt](https://github.com/NeogitOrg/neogit/blob/6af8fc6b03210d0ac99398f8eff27c5be7b2ba8a/doc/neogit.txt#L155-L157) as

```lua
  preview_buffer = {
    kind = "split",
  },
```

but was set to `kind = "floating"`.