### PR TITLE
Handle target function exceptions in throttle_by_id

### DIFF
--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -574,7 +574,7 @@ function M.throttle_by_id(fn, schedule)
     while scheduled[id] do
       scheduled[id] = nil
       running[id] = true
-      fn(id, ...)
+      pcall(fn, id, ...)
       running[id] = nil
     end
   end


### PR DESCRIPTION
Hey!

I've noticed that if a throttled function fails it's considered to be running and any subsequent calls would be cancelled. This PR fixes that by running the target function in protected mode.