### PR TITLE
Improve window splitting options for `kind`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ neogit.setup {
     -- Accepted values:
     -- "split" to show the staged diff below the commit editor
     -- "vsplit" to show it to the right
-    -- "split_above" Like :top split
+    -- "split_above" Like :above split
+    -- "split_bottom" Like :bottom split
+    -- "split_top" Like :top split
     -- "vsplit_left" like :vsplit, but open to the left
     -- "auto" "vsplit" if window would have 80 cols, otherwise "split"
     staged_diff_split_kind = "split"
@@ -401,7 +403,10 @@ The `kind` option can be one of the following values:
 - `replace`
 - `split`
 - `split_above`
+- `split_top`
+- `split_bottom`
 - `vsplit`
+- `vsplit_left`
 - `auto` (`vsplit` if window would have 80 cols, otherwise `split`)
 
 ## Popups

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -566,7 +566,9 @@ neogit.open({*opts})                                             *neogit.open()*
                     - "tab" (default) like :tab split
                     - "replace"       like :enew
                     - "split"         like :below split
-                    - "split_above"   like :top split
+                    - "split_above"   like :above split
+                    - "split_top"     like :top split
+                    - "split_bottom"  like :bottom split
                     - "vsplit"        like :vsplit
                     - "vsplit_left"   like :vsplit, but open to the left
                     - "floating" not-yet-implemented

--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -242,6 +242,8 @@ function M.complete(arglead)
       "kind=tab",
       "kind=split",
       "kind=split_above",
+      "kind=split_top",
+      "kind=split_bottom",
       "kind=vsplit",
       "kind=floating",
       "kind=auto",

--- a/lua/neogit/buffers/status/init.lua
+++ b/lua/neogit/buffers/status/init.lua
@@ -70,7 +70,7 @@ function M:_action(name)
   return action(self)
 end
 
----@param kind string<"floating" | "split" | "tab" | "split" | "vsplit">|nil
+---@param kind ?WindowKind
 ---@param cwd string
 ---@return StatusBuffer
 function M:open(kind, cwd)

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -80,9 +80,14 @@ end
 
 ---@alias WindowKind
 ---| "split" Open in a split
+---| "split_above" Like :above split
+---| "split_top" Like :top split
+---| "split_bottom" Like :bottom split
 ---| "vsplit" Open in a vertical split
+---| "vsplit_left" like :vsplit, but open to the left
 ---| "floating" Open in a floating window
 ---| "tab" Open in a new tab
+---| "auto" "vsplit" if window would have 80 cols, otherwise "split"
 
 ---@class NeogitCommitBufferConfig Commit buffer options
 ---@field kind WindowKind The type of window that should be opened
@@ -93,8 +98,11 @@ end
 
 ---@alias StagedDiffSplitKind
 ---| "split" Open in a split
+---| "split_above" Like :above split
+---| "split_top" Like :top split
+---| "split_bottom" Like :bottom split
 ---| "vsplit" Open in a vertical split
----| "split_above" Like :top split
+---| "vsplit_left" like :vsplit, but open to the left
 ---| "auto" "vsplit" if window would have 80 cols, otherwise "split"
 
 ---@class NeogitCommitEditorConfigPopup Popup window options
@@ -635,14 +643,14 @@ function M.validate_config()
     if
       validate_type(val, name, "string")
       and not vim.tbl_contains(
-        { "split", "vsplit", "split_above", "vsplit_left", "tab", "floating", "replace", "auto" },
+        { "split", "vsplit", "split_above", "split_top", "split_bottom", "vsplit_left", "tab", "floating", "replace", "auto" },
         val
       )
     then
       err(
         name,
         string.format(
-          "Expected `%s` to be one of 'split', 'vsplit', 'split_above', 'vsplit_left', tab', 'floating', 'replace' or 'auto', got '%s'",
+          "Expected `%s` to be one of 'split', 'vsplit', 'split_above', 'split_top', 'split_bottom', 'vsplit_left', tab', 'floating', 'replace' or 'auto', got '%s'",
           name,
           val
         )

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -281,6 +281,10 @@ function Buffer:show()
     win = api.nvim_open_win(self.handle, true, { split = "below" })
   elseif kind == "split_above" then
     win = api.nvim_open_win(self.handle, true, { split = "above" })
+  elseif kind == "split_top" then
+    win = api.nvim_open_win(self.handle, true, { split = "above", win = -1 })
+  elseif kind == "split_bottom" then
+    win = api.nvim_open_win(self.handle, true, { split = "below", win = -1 })
   elseif kind == "vsplit" then
     win = api.nvim_open_win(self.handle, true, { split = "right", vertical = true })
   elseif kind == "vsplit_left" then

--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -14,7 +14,7 @@ local Path = require("plenary.path")
 ---@field namespaces table
 ---@field autocmd_group number
 ---@field ui Ui
----@field kind string
+---@field kind WindowKind
 ---@field disable_line_numbers boolean
 ---@field disable_relative_line_numbers boolean
 local Buffer = {
@@ -533,7 +533,7 @@ end
 
 ---@class BufferConfig
 ---@field name string
----@field kind string
+---@field kind ?WindowKind
 ---@field filetype string|nil
 ---@field bufhidden string|nil
 ---@field header string|nil

--- a/lua/neogit/lib/popup/init.lua
+++ b/lua/neogit/lib/popup/init.lua
@@ -369,7 +369,9 @@ function M:show()
         end
       end
 
-      if config.values.popup.kind == "split" or config.values.popup.kind == "split_above" then
+      local kinds_to_resize = { "split", "split_above", "split_top", "split_bottom" }
+      local should_resize = vim.tbl_contains(kinds_to_resize, config.values.popup.kind)
+      if should_resize then
         vim.cmd.resize(vim.fn.line("$") + 1)
 
         -- We do it again because things like the BranchConfigPopup come from an async context,

--- a/tests/specs/neogit/config_spec.lua
+++ b/tests/specs/neogit/config_spec.lua
@@ -480,7 +480,7 @@ describe("Neogit config", function()
       end)
 
       it("should return valid when kind is a valid window kind", function()
-        config.values.kind = "floating"
+        config.values.kind = "auto"
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
       end)
 
@@ -495,7 +495,7 @@ describe("Neogit config", function()
       end)
 
       it("should return valid when commit_select_view.kind is a valid window kind", function()
-        config.values.commit_select_view.kind = "tab"
+        config.values.commit_select_view.kind = "split_top"
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
       end)
 
@@ -505,7 +505,7 @@ describe("Neogit config", function()
       end)
 
       it("should return valid when log_view.kind is a valid window kind", function()
-        config.values.log_view.kind = "vsplit"
+        config.values.log_view.kind = "split_bottom"
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
       end)
 
@@ -515,7 +515,7 @@ describe("Neogit config", function()
       end)
 
       it("should return valid when reflog_view.kind is a valid window kind", function()
-        config.values.reflog_view.kind = "vsplit"
+        config.values.reflog_view.kind = "split"
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
       end)
 
@@ -525,7 +525,7 @@ describe("Neogit config", function()
       end)
 
       it("should return valid when preview_buffer.kind is a valid window kind", function()
-        config.values.preview_buffer.kind = "floating"
+        config.values.preview_buffer.kind = "vsplit_left"
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
       end)
 


### PR DESCRIPTION
## Changes

Add two new options for `kind` which are `split_top` and `split_bottom`. Those allow the window to be split as the top/bottom most window (That'd be the same as `:top split` and `:bottom split`  respectively). 
Also, correct the actual behavior of `split_above` in the docs/comments.

## Screenshots

### With `kind=split` as usual:
![image](https://github.com/user-attachments/assets/b35c7a6e-de43-4827-bbf2-84a4a98f385c)

### With the new `kind=split_bottom`:
![image](https://github.com/user-attachments/assets/90861320-3614-4e85-a25f-3f126dd8740d)

Note: `split_above` and `split_top` do the same thing but at the top, of course.