### PR TITLE
fix(#383): Make RPC work with tcp servers

### DIFF
--- a/lua/neogit/lib/rpc.lua
+++ b/lua/neogit/lib/rpc.lua
@@ -25,7 +25,9 @@ function RPC.create_connection(address)
 end
 
 function RPC:connect()
-  self.ch = vim.fn.sockconnect("pipe", self.address, { rpc = true })
+  -- assume TPC if the address ends with :<some numbers>
+  local mode = self.address:match(":%d+$") and "tcp" or "pipe"
+  self.ch = vim.fn.sockconnect(mode, self.address, { rpc = true })
 end
 
 function RPC:disconnect()


### PR DESCRIPTION
When nvim is started with `nvim --listen 127.0.0.1:9999`, rpc connections don't work because `vim.fn.sockconnect` is always called with `pipe` mode.

We can examine the server address and use `tcp` mode if the address looks like `servername:port`.

fixes #383