### PR TITLE
Add support for YubiKey "Enter PIN for"

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -877,7 +877,7 @@ local function handle_line_interactive(p, line)
     handler = handle_interactive_authenticity
   elseif line:match("^Username for ") then
     handler = handle_interactive_username
-  elseif line:match("^Enter passphrase") or line:match("^Password for") then
+  elseif line:match("^Enter passphrase") or line:match("^Password for") or line:match("^Enter PIN for") then
     handler = handle_interactive_password
   end
 


### PR DESCRIPTION
Allows interaction with the YubiKey PIN prompt. This will allow users to use their passkeys with PINs for Git operations.