### PR TITLE
fix: don't use config.highlight on autocommands

### DIFF
--- a/lua/neogit/lib/hl.lua
+++ b/lua/neogit/lib/hl.lua
@@ -128,7 +128,7 @@ local function make_palette(config)
     underline  = true,
   }
 
-  return vim.tbl_extend("keep", config.highlight, default)
+  return vim.tbl_extend("keep", config.highlight or {}, default)
 end
 -- stylua: ignore end
 


### PR DESCRIPTION
Whenever colorscheme changes the `setup` function of `hl.lua` is called, which then tries to create a palette from the passed config (also considering the defaults). 

The problem was that when `ColorScheme` autocommand triggers this change, the field `config.highlight` is missing. So in this case we should ignore it.  

Fixes #1505.