### PR TITLE
fix: windowkind types

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -79,10 +79,16 @@ function M.get_user_mappings(set)
 end
 
 ---@alias WindowKind
+---| "replace" Like :enew
+---| "tab" Open in a new tab
 ---| "split" Open in a split
+---| "split_above" Like :top split
+---| "split_above_all" Like :top split
+---| "split_below" Like :below split
+---| "split_below_all" Like :below split
 ---| "vsplit" Open in a vertical split
 ---| "floating" Open in a floating window
----| "tab" Open in a new tab
+---| "auto" vsplit if window would have 80 cols, otherwise split
 
 ---@class NeogitCommitBufferConfig Commit buffer options
 ---@field kind WindowKind The type of window that should be opened


### PR DESCRIPTION
While configuring this plugin, my LSP kept saying the kind I chose was an error because it was not in the `WindowKind` alias

This PR adds types to the WindowKind alias
referenced: https://github.com/NeogitOrg/neogit/blob/master/lua/neogit.lua#L231
and the [usage part of the readme](https://github.com/NeogitOrg/neogit/tree/master?tab=readme-ov-file#usage) that states which kinds are valid.