### PR TITLE
Fix trying to perform arithmetic on nil hunk_offset

### DIFF
--- a/lua/neogit/lib/ui/init.lua
+++ b/lua/neogit/lib/ui/init.lua
@@ -504,7 +504,7 @@ function Ui:resolve_cursor_location(cursor)
 
   if cursor.hunk.index_from == hunk.index_from then
     logger.debug(("[UI] Using hunk.first with offset %q"):format(cursor.hunk.name))
-    return hunk.first + cursor.hunk_offset - (cursor.last - hunk.last)
+    return hunk.first + (cursor.hunk_offset or 0) - (cursor.last - hunk.last)
   else
     logger.debug(("[UI] Using hunk.first %q"):format(cursor.hunk.name))
     return hunk.first


### PR DESCRIPTION
I got this locally. I'm not sure how I got there, but there I was:

```
...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:18: The coroutine failed with this message: ....local/share/nvim/lazy/neogit/lua/neogit/lib/ui/init.lua:507: attempt to perform arithmetic on field 'hunk _offset' (a nil value)
stack traceback:
^I[C]: in function 'error'
^I...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:18: in function 'callback_or_next'
^I...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:45: in function 'step'
^I...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:48: in function 'execute'
^I...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:118: in function 'callback'
^I...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:25: in function 'callback_or_next'
^I...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:45: in function 'saved_callback'
^I...are/nvim/lazy/plenary.nvim/lua/plenary/async/control.lua:126: in function 'tx'
^I.../share/nvim/lazy/plenary.nvim/lua/plenary/async/util.lua:71: in function 'callback'
^I...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:25: in function 'callback_or_next'
^I...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:45: in function 'cb'
^I...sto/.local/share/nvim/lazy/neogit/lua/neogit/process.lua:334: in function <...sto/.local/share/nvim/lazy/neogit/lua/neogit/process.lua:292>
```

See `attempt to perform arithmetic on field 'hunk _offset' (a nil value)`. This PR works around that by defaulting to `0` if there is no `hunk_offset`.