### PR TITLE
fix: process.lua error when we have a bare repo in the worktree list

### DIFF
--- a/lua/neogit/lib/git/worktree.lua
+++ b/lua/neogit/lib/git/worktree.lua
@@ -48,20 +48,22 @@ function M.list(opts)
   local list = git.cli.worktree.list.args("--porcelain").call({ hidden = true }).stdout
 
   local worktrees = {}
-  for i = 1, #list, 3 do
-    local path = list[i]:match("^worktree (.-)$")
-    local head = list[i]:match("^HEAD (.-)$")
-    local type, ref = list[i + 2]:match("^([^ ]+) (.+)$")
+  for i = 1, #list, 1 do
+    if list[i]:match("^branch.*$") then
+      local path = list[i - 2]:match("^worktree (.-)$")
+      local head = list[i - 1]:match("^HEAD (.-)$")
+      local type, ref = list[i]:match("^([^ ]+) (.+)$")
 
-    if path then
-      local main = Path.new(path, ".git"):is_dir()
-      table.insert(worktrees, {
-        head = head,
-        type = type,
-        ref = ref,
-        main = main,
-        path = path,
-      })
+      if path then
+        local main = Path.new(path, ".git"):is_file()
+        table.insert(worktrees, {
+          head = head,
+          type = type,
+          ref = ref,
+          main = main,
+          path = path,
+        })
+      end
     end
   end
 


### PR DESCRIPTION
When generating a list of worktrees using the 'git worktree list --porcelain' command, a bare worktree only has 2 lines, whereas all other worktrees have 3 lines. Since we don't need to switch to the bare repo, we can safely ignore it. The new listing function will look for a branch listing and only add that to the list of worktrees. 

```
worktree /tmp/ws-nvim/.repos/neogit.git
bare

worktree /tmp/ws-nvim/neogit-bare-worktree-listing-error
HEAD 2b770465b79dfe60898983ddfc897cdf08cf9d34
branch refs/heads/fix-bare-worktree-listing-error

worktree /tmp/ws-nvim/neogit-master
HEAD bae3412ea9ac31292e14e9090dde7cb118cd52c1
branch refs/heads/master
```