### PR TITLE
feat: Add auto_show_console_on = "output" | "error" setting

### DIFF
--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -120,6 +120,9 @@ TODO: Detail what these do
     console_timeout = 2000,
     -- Automatically show console if a command takes more than console_timeout milliseconds
     auto_show_console = true,
+    -- If `auto_show_console` is enabled, specify "output" (default) to show
+    -- the console always, or "error" to auto-show the console only on error
+    auto_show_console_on = "output",
     notification_icon = "󰊢",
     status = {
       recent_commit_count = 10,

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -317,6 +317,7 @@ end
 ---@field disable_relative_line_numbers? boolean Whether to disable line numbers
 ---@field console_timeout? integer Time in milliseconds after a console is created for long running commands
 ---@field auto_show_console? boolean Automatically show the console if a command takes longer than console_timeout
+---@field auto_show_console_on? string Specify "output" (show always; default) or "error" if `auto_show_console` enabled
 ---@field auto_close_console? boolean Automatically hide the console if the process exits with a 0 status
 ---@field status? NeogitConfigStatusOptions Status buffer options
 ---@field commit_editor? NeogitCommitEditorConfigPopup Commit editor options
@@ -377,6 +378,9 @@ function M.get_default_values()
     console_timeout = 2000,
     -- Automatically show console if a command takes more than console_timeout milliseconds
     auto_show_console = true,
+    -- If `auto_show_console` is enabled, specify "output" (default) to show
+    -- the console always, or "error" to auto-show the console only on error
+    auto_show_console_on = "output",
     auto_close_console = true,
     notification_icon = "󰊢",
     status = {
@@ -1107,6 +1111,7 @@ function M.validate_config()
     validate_type(config.disable_line_numbers, "disable_line_numbers", "boolean")
     validate_type(config.disable_relative_line_numbers, "disable_relative_line_numbers", "boolean")
     validate_type(config.auto_show_console, "auto_show_console", "boolean")
+    validate_type(config.auto_show_console_on, "auto_show_console_on", "string")
     validate_type(config.auto_close_console, "auto_close_console", "boolean")
     if validate_type(config.status, "status", "table") then
       validate_type(config.status.show_head_commit_hash, "status.show_head_commit_hash", "boolean")

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -152,16 +152,15 @@ function Process:start_timer()
           return
         end
 
-        if config.values.auto_show_console then
-          self:show_console()
-        else
+        if not config.values.auto_show_console then
           local message = string.format(
             "Command %q running for more than: %.1f seconds",
             mask_command(table.concat(self.cmd, " ")),
             math.ceil((vim.uv.now() - self.start) / 100) / 10
           )
-
           notification.warn(message .. "\n\nOpen the command history for details")
+        elseif config.values.auto_show_console_on == "output" then
+          self:show_console()
         end
       end)
     )
@@ -336,10 +335,13 @@ function Process:spawn(cb)
           insert(output, "> " .. util.remove_ansi_escape_codes(res.stderr[i]))
         end
 
-        local message =
-          string.format("%s:\n\n%s", mask_command(table.concat(self.cmd, " ")), table.concat(output, "\n"))
-
-        notification.warn(message)
+        if not config.values.auto_close_console then
+          local message =
+            string.format("%s:\n\n%s", mask_command(table.concat(self.cmd, " ")), table.concat(output, "\n"))
+          notification.warn(message)
+        elseif config.values.auto_show_console_on == "error" then
+          self.buffer:show()
+        end
       end
 
       if

--- a/tests/specs/neogit/config_spec.lua
+++ b/tests/specs/neogit/config_spec.lua
@@ -82,7 +82,12 @@ describe("Neogit config", function()
       end)
 
       it("should return invalid when auto_show_console isn't a boolean", function()
-        config.values.console_timeout = "not a boolean"
+        config.values.auto_show_console = "not a boolean"
+        assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when auto_show_console_on isn't a string", function()
+        config.values.auto_show_console_on = true
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
       end)
 


### PR DESCRIPTION
This pairs very well with the new spinner feature: https://github.com/NeogitOrg/neogit/pull/1551

Allows users to set:

```lua
{ auto_show_console_on = "error" }
```

Note that this is only considered if `auto_show_console` is `true` (this is the default).

This results in Neogit showing a spinner while, e.g. pre-commit hooks are running, and only shows the console if the pre-commit hooks fail.

The default is `auto_show_console_on = "output"`, which matches the previous behavior.

This PR also stops Neogit from calling `notification.warn` on a bad exit code, because this overlaps with showing the console, and requires the user to press enter unnecessarily in order to get to the console output. The `notification.warn` call is preserved if `auto_show_console` is `false`.