### PR TITLE
fix: prevent deletion of the main worktree

### DIFF
--- a/lua/neogit/lib/git/worktree.lua
+++ b/lua/neogit/lib/git/worktree.lua
@@ -55,7 +55,7 @@ function M.list(opts)
       local type, ref = list[i]:match("^([^ ]+) (.+)$")
 
       if path then
-        local main = Path.new(path, ".git"):is_file()
+        local main = Path.new(path, ".git"):is_dir()
         table.insert(worktrees, {
           head = head,
           type = type,


### PR DESCRIPTION
Ensure the main worktree, which contains a .git directory, is not deleted by filtering it out from the list of worktrees. Mark any worktree with a .git directory as the main worktree to protect it from deletion.