### PR TITLE
Make spinner step messages transient

### DIFF
--- a/lua/neogit/spinner.lua
+++ b/lua/neogit/spinner.lua
@@ -36,13 +36,15 @@ end
 function Spinner:start()
   if not self.timer then
     self.timer = vim.uv.new_timer()
+    vim.cmd(string.format("redraw | echomsg '[neogit] %s'", self.text))
+
     self.timer:start(
       250,
       self.interval,
       vim.schedule_wrap(function()
         self.count = self.count + 1
         local step = self.pattern[(self.count % #self.pattern) + 1]
-        vim.cmd(string.format("redraw | echomsg '%s %s'", step, self.text))
+        vim.cmd(string.format("redraw | echo '%s %s'", step, self.text))
       end)
     )
   end


### PR DESCRIPTION
Hi @CKolkey, I've been enjoying neogit for a while, and was pleasantly surprised when I saw the spinner messages on most git operation. Thank you!

However, I've run into a small conflict with the spinner steps. Using `echom` pushes the messages into the message history, which means that if the git operation is long enough, we'll pollute the history with redundant messages.

For some context, those messages are useful to explore the output of different processes, specially when a plugin throws an error.

You can explore the history using the built-in `:messages` command, or you can use something like `:Message` from vim-scriptease which sends the message history into the quickfix window.

In this case, I ran an amend on this commit and took a few seconds to reword the message, that sent 93 messages into the history:

<img width="1754" alt="Screenshot 2024-11-13 at 09 30 19" src="https://github.com/user-attachments/assets/53129656-7479-4414-bd8d-b210c62b39e7">

Since it would be great to keep at least one entry in the history, in this commit I'm adding one entry to the messages history, prefixed with `[neogit]` and then replace the spinner step messages with `echo`, which also prints the message but it doesn't save it in the history.

<img width="1754" alt="Screenshot 2024-11-13 at 09 26 46" src="https://github.com/user-attachments/assets/d8c9e7c5-eed0-4ebc-8852-666b7d5d93ba">
