### PR TITLE
Remove non-existent `StageLine` keymap from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,6 @@ neogit.setup {
       ["x"] = "Discard",
       ["s"] = "Stage",
       ["S"] = "StageUnstaged",
-      ["L"] = "StageLine",
       ["<c-s>"] = "StageAll",
       ["u"] = "Unstage",
       ["K"] = "Untrack",

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -355,7 +355,6 @@ The following mappings can all be customized via the setup function.
         ["x"]      = "Discard",
         ["s"]      = "Stage",
         ["S"]      = "StageUnstaged",
-        ["L"]      = "StageLine",
         ["<c-s>"]  = "StageAll",
         ["u"]      = "Unstage",
         ["K"]      = "Untrack",


### PR DESCRIPTION
In #1572 I've accidentally added a `["L"] = "StageLine"` keymap that does not exist in upstream `HEAD`. It is a feature that I'm working on locally. Sorry for the noise.