### PR TITLE
Handle detached head in log popup

### DIFF
--- a/lua/neogit/popups/log/actions.lua
+++ b/lua/neogit/popups/log/actions.lua
@@ -32,14 +32,13 @@ local function fetch_more_commits(popup, flags)
   end
 end
 
--- TODO: Handle when head is detached
 function M.log_current(popup)
   LogViewBuffer.new(
     commits(popup, {}),
     popup:get_internal_arguments(),
     popup.state.env.files,
     fetch_more_commits(popup, {}),
-    "Commits in " .. git.branch.current(),
+    "Commits in " .. git.branch.current() or ("(detached) " .. git.log.message("HEAD")),
     git.remote.list()
   ):open()
 end


### PR DESCRIPTION
When in detached HEAD, the log view crashes because there is no current branch.

This fixes the issue by checking if `git.branch.current()` is `nil` and if it is, creates a custom message "(detached) <subject>".