### PR TITLE
Support configuring popup kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ neogit.setup {
     kind = "floating_console",
   },
   popup = {
-    kind = "split",
+    kind = "popup",
   },
   stash = {
     kind = "tab",

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -160,7 +160,7 @@ TODO: Detail what these do
       kind = "split",
     },
     popup = {
-      kind = "split",
+      kind = "popup",
     },
     refs_view = {
       kind = "tab",

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -88,6 +88,7 @@ end
 ---| "split_below_all" Like :below split
 ---| "vsplit" Open in a vertical split
 ---| "floating" Open in a floating window
+---| "popup" Open in a popup
 ---| "auto" vsplit if window would have 80 cols, otherwise split
 
 ---@class NeogitCommitBufferConfig Commit buffer options
@@ -442,7 +443,7 @@ function M.get_default_values()
       kind = "floating_console",
     },
     popup = {
-      kind = "split",
+      kind = "popup",
     },
     stash = {
       kind = "tab",
@@ -692,13 +693,14 @@ function M.validate_config()
         "floating",
         "floating_console",
         "replace",
+        "popup",
         "auto",
       }, val)
     then
       err(
         name,
         string.format(
-          "Expected `%s` to be one of 'split', 'vsplit', 'split_above', 'vsplit_left', tab', 'floating', 'replace' or 'auto', got '%s'",
+          "Expected `%s` to be one of 'split', 'vsplit', 'split_above', 'split_above_all', 'split_below', 'split_below_all', 'vsplit_left', tab', 'floating', 'floating_console', 'replace', 'popup' or 'auto', got '%s'",
           name,
           val
         )

--- a/lua/neogit/lib/popup/init.lua
+++ b/lua/neogit/lib/popup/init.lua
@@ -1,3 +1,4 @@
+local config = require("neogit.config")
 local PopupBuilder = require("neogit.lib.popup.builder")
 local Buffer = require("neogit.lib.buffer")
 local logger = require("neogit.logger")
@@ -407,7 +408,7 @@ function M:show()
   self.buffer = Buffer.create {
     name = self.state.name,
     filetype = "NeogitPopup",
-    kind = "popup",
+    kind = config.values.popup.kind,
     mappings = self:mappings(),
     status_column = " ",
     autocmds = {


### PR DESCRIPTION
Adds support for the `popup.kind` config along with some changes to the validation to support the default `"popup"` kind