### PR TITLE
Add custom date format options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ neogit.setup {
   -- "kitty"   is the graph like https://github.com/isakbm/gitgraph.nvim - use https://github.com/rbong/flog-symbols if you don't use Kitty
   graph_style = "ascii",
   -- Show relative date by default. When set, use `strftime` to display dates
+  commit_date_format = nil,
   log_date_format = nil,
   -- Used to generate URL's for branch popup action "pull request".
   git_services = {

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ neogit.setup {
   -- "unicode" is the graph like https://github.com/rbong/vim-flog
   -- "kitty"   is the graph like https://github.com/isakbm/gitgraph.nvim - use https://github.com/rbong/flog-symbols if you don't use Kitty
   graph_style = "ascii",
+  -- Show relative date by default. When set, use `strftime` to display dates
+  log_date_format = nil,
   -- Used to generate URL's for branch popup action "pull request".
   git_services = {
     ["github.com"] = "https://github.com/${owner}/${repository}/compare/${branch_name}?expand=1",

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -89,6 +89,7 @@ TODO: Detail what these do
     disable_context_highlighting = false,
     disable_signs = false,
     graph_style = "ascii",
+    log_date_format = nil,
     filewatcher = {
       enabled = true,
     },

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -89,6 +89,7 @@ TODO: Detail what these do
     disable_context_highlighting = false,
     disable_signs = false,
     graph_style = "ascii",
+    commit_date_format = nil,
     log_date_format = nil,
     filewatcher = {
       enabled = true,

--- a/lua/neogit/buffers/commit_view/init.lua
+++ b/lua/neogit/buffers/commit_view/init.lua
@@ -47,8 +47,11 @@ local M = {
 ---@param filter? string[] Filter diffs to filepaths in table
 ---@return CommitViewBuffer
 function M.new(commit_id, filter)
-  local commit_info =
-    git.log.parse(git.cli.show.format("fuller").args(commit_id).call({ trim = false }).stdout)[1]
+  local cmd = git.cli.show.format("fuller").args(commit_id)
+  if config.values.commit_date_format ~= nil then
+    cmd = cmd.args("--date=format:" .. config.values.commit_date_format)
+  end
+  local commit_info = git.log.parse(cmd.call({ trim = false }).stdout)[1]
 
   commit_info.commit_arg = commit_id
 

--- a/lua/neogit/buffers/common.lua
+++ b/lua/neogit/buffers/common.lua
@@ -1,6 +1,7 @@
 local Ui = require("neogit.lib.ui")
 local Component = require("neogit.lib.ui.component")
 local util = require("neogit.lib.util")
+local config = require("neogit.config")
 local git = require("neogit.lib.git")
 
 local text = Ui.text
@@ -247,6 +248,8 @@ M.CommitEntry = Component.new(function(commit, remotes, args)
     }
   end
 
+  local date = (config.values.log_date_format == nil and commit.rel_date or commit.log_date)
+
   return col.tag("commit")({
     row(
       util.merge({
@@ -260,10 +263,10 @@ M.CommitEntry = Component.new(function(commit, remotes, args)
         virtual_text = {
           { " ", "Constant" },
           {
-            util.str_clamp(commit.author_name, 30 - (#commit.rel_date > 10 and #commit.rel_date or 10)),
+            util.str_clamp(commit.author_name, 30 - (#date > 10 and #date or 10)),
             "NeogitGraphAuthor",
           },
-          { util.str_min_width(commit.rel_date, 10), "Special" },
+          { util.str_min_width(date, 10), "Special" },
         },
       }
     ),

--- a/lua/neogit/buffers/reflog_view/ui.lua
+++ b/lua/neogit/buffers/reflog_view/ui.lua
@@ -1,6 +1,7 @@
 local Ui = require("neogit.lib.ui")
 local Component = require("neogit.lib.ui.component")
 local util = require("neogit.lib.util")
+local config = require("neogit.config")
 
 local col = Ui.col
 local row = Ui.row
@@ -25,7 +26,13 @@ local function highlight_for_type(type)
 end
 
 M.Entry = Component.new(function(entry, total)
-  local date_number, date_quantifier = unpack(vim.split(entry.rel_date, " "))
+  local date
+  if config.values.log_date_format == nil then
+    local date_number, date_quantifier = unpack(vim.split(entry.rel_date, " "))
+    date = date_number .. date_quantifier:sub(1, 1)
+  else
+    date = entry.commit_date
+  end
 
   return col({
     row({
@@ -38,7 +45,7 @@ M.Entry = Component.new(function(entry, total)
       virtual_text = {
         { " ", "Constant" },
         -- { util.str_clamp(entry.author_name, 20 - #tostring(date_number)), "Constant" },
-        { date_number .. date_quantifier:sub(1, 1), "Special" },
+        { date, "Special" },
       },
     }),
   }, { oid = entry.oid })

--- a/lua/neogit/buffers/stash_list_view/ui.lua
+++ b/lua/neogit/buffers/stash_list_view/ui.lua
@@ -1,6 +1,7 @@
 local Ui = require("neogit.lib.ui")
 local Component = require("neogit.lib.ui.component")
 local util = require("neogit.lib.util")
+local config = require("neogit.config")
 
 local text = Ui.text
 local col = Ui.col
@@ -19,7 +20,7 @@ M.Stash = Component.new(function(stash)
     }, {
       virtual_text = {
         { " ", "Constant" },
-        { stash.rel_date, "Special" },
+        { config.values.log_date_format ~= nil and stash.date or stash.rel_date, "Special" },
       },
     }),
   }, { oid = label })

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -300,6 +300,7 @@ end
 ---@class NeogitConfig Neogit configuration settings
 ---@field filewatcher? NeogitFilewatcherConfig Values for filewatcher
 ---@field graph_style? NeogitGraphStyle Style for graph
+---@field commit_date_format? string Commit date format
 ---@field log_date_format? string Log date format
 ---@field disable_hint? boolean Remove the top hint in the Status buffer
 ---@field disable_context_highlighting? boolean Disable context highlights based on cursor position
@@ -352,6 +353,7 @@ function M.get_default_values()
     disable_context_highlighting = false,
     disable_signs = false,
     graph_style = "ascii",
+    commit_date_format = nil,
     log_date_format = nil,
     process_spinner = true,
     filewatcher = {

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -300,6 +300,7 @@ end
 ---@class NeogitConfig Neogit configuration settings
 ---@field filewatcher? NeogitFilewatcherConfig Values for filewatcher
 ---@field graph_style? NeogitGraphStyle Style for graph
+---@field log_date_format? string Log date format
 ---@field disable_hint? boolean Remove the top hint in the Status buffer
 ---@field disable_context_highlighting? boolean Disable context highlights based on cursor position
 ---@field disable_signs? boolean Special signs to draw for sections etc. in Neogit
@@ -351,6 +352,7 @@ function M.get_default_values()
     disable_context_highlighting = false,
     disable_signs = false,
     graph_style = "ascii",
+    log_date_format = nil,
     process_spinner = true,
     filewatcher = {
       enabled = true,

--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -29,6 +29,7 @@ local commit_header_pat = "([| ]*)(%*?)([| ]*)commit (%w+)"
 ---@field body string
 ---@field verification_flag string?
 ---@field rel_date string
+---@field log_date string
 
 ---Parses the provided list of lines into a CommitLogEntry
 ---@param raw string[]
@@ -287,6 +288,17 @@ local function determine_order(options, graph)
   return options
 end
 
+--- Specifies date format when not using relative dates
+--- @param options table
+--- @return table, string|nil
+local function set_date_format(options)
+  if config.values.log_date_format ~= nil then
+    table.insert(options, "--date=format:" .. config.values.log_date_format)
+  end
+
+  return options
+end
+
 ---@param options table|nil
 ---@param files? table
 ---@param color? boolean
@@ -327,6 +339,7 @@ local function format(show_signature)
     committer_email = "%cE",
     committer_date = "%cD",
     rel_date = "%cr",
+    log_date = "%cd",
   }
 
   if show_signature then
@@ -352,6 +365,7 @@ M.list = util.memoize(function(options, graph, files, hidden, graph_color)
   options = ensure_max(options or {})
   options = determine_order(options, graph)
   options, signature = show_signature(options)
+  options = set_date_format(options)
 
   local output = git.cli.log
     .format(format(signature))

--- a/lua/neogit/lib/git/reflog.lua
+++ b/lua/neogit/lib/git/reflog.lua
@@ -1,5 +1,6 @@
 local git = require("neogit.lib.git")
 local util = require("neogit.lib.util")
+local config = require("neogit.config")
 
 ---@class NeogitGitReflog
 local M = {}
@@ -15,7 +16,7 @@ local function parse(entries)
 
   return util.filter_map(entries, function(entry)
     index = index + 1
-    local hash, author, name, subject, date = unpack(vim.split(entry, "\30"))
+    local hash, author, name, subject, rel_date, commit_date = unpack(vim.split(entry, "\30"))
     local command, message = subject:match([[^(.-): (.*)]])
     if not command then
       command = subject:match([[^(.-):]])
@@ -42,7 +43,8 @@ local function parse(entries)
       author_name = author,
       ref_name = name,
       ref_subject = message,
-      rel_date = date,
+      rel_date = rel_date,
+      commit_date = commit_date,
       type = command,
     }
   end)
@@ -55,15 +57,23 @@ function M.list(refname, options)
     "%gd", -- Reflog Name
     "%gs", -- Reflog Subject
     "%cr", -- Commit Date (Relative)
+    "%cd", -- Commit Date
   }, "%x1E")
 
   util.remove_item_from_table(options, "--simplify-by-decoration")
   util.remove_item_from_table(options, "--follow")
 
+  local date_format
+  if config.values.log_date_format ~= nil then
+    date_format = "format:" .. config.values.log_date_format
+  else
+    date_format = "raw"
+  end
+
   return parse(
     git.cli.reflog.show
       .format(format)
-      .date("raw")
+      .date(date_format)
       .arg_list(options or {})
       .args(refname, "--")
       .call({ hidden = true }).stdout

--- a/lua/neogit/lib/git/stash.lua
+++ b/lua/neogit/lib/git/stash.lua
@@ -1,6 +1,7 @@
 local git = require("neogit.lib.git")
 local input = require("neogit.lib.input")
 local util = require("neogit.lib.util")
+local config = require("neogit.config")
 
 ---@class NeogitGitStash
 local M = {}
@@ -89,6 +90,7 @@ end
 ---@class StashItem
 ---@field idx number string the id of the stash i.e. stash@{7}
 ---@field name string
+---@field date string timestamp
 ---@field rel_date string relative timestamp
 ---@field message string the message associated with each stash.
 
@@ -118,6 +120,15 @@ function M.register(meta)
               .call({ hidden = true }).stdout[1]
 
             return self.rel_date
+          elseif key == "date" then
+            self.date = git.cli.log
+              .max_count(1)
+              .format("%cd")
+              .args("--date=format:" .. config.values.log_date_format)
+              .args(("stash@{%s}"):format(idx))
+              .call({ hidden = true }).stdout[1]
+
+            return self.date
           end
         end,
       })


### PR DESCRIPTION
This adds the options:

- `commit_date_format`: Applied to the commit view.
- `log_date_format`: Applied to all the dates in a log like view. This includes the log, reflog, stashes.

Closes #1568.