### PR TITLE
Add TODO's section to status buffer - WIP:

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ neogit.setup {
       folded = true,
       hidden = false,
     },
+    todo = {
+      folded = true,
+      hidden = false,
+    },
   },
   mappings = {
     commit_editor = {

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -1835,6 +1835,15 @@ Untracked Files                                 *neogit_status_buffer_untracked*
   untracked files entirely, "normal" to show files and directories (default),
   or "all" to show all files in all directories.
 
+TODOs                                               *neogit_status_buffer_todos*
+  Requires `ripgrep` and `sort` to be available on your system. By default,
+  finds all TODO notes in the codebase matching:
+  - " TODO: "
+  - " NOTE: "
+  - " FIXME: "
+  - " HACK: "
+
+  Can be configured to find other/different keywords.
 ==============================================================================
 Editor Buffer                                             *neogit_editor_buffer*
 

--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -1124,6 +1124,13 @@ M.n_goto_file = function(self)
   return function()
     local item = self.buffer.ui:get_item_under_cursor()
 
+    -- Goto PLUGIN (TODO, etc...)
+    if item and item.goto_path and item.goto_cursor then
+      self:close()
+      vim.schedule_wrap(open)("edit", item.goto_path, item.goto_cursor)
+      return
+    end
+
     -- Goto FILE
     if item and item.absolute_path then
       local cursor = translate_cursor_location(self, item)
@@ -1145,6 +1152,12 @@ M.n_tab_open = function(self)
   return function()
     local item = self.buffer.ui:get_item_under_cursor()
 
+    -- Goto PLUGIN (TODO, etc...)
+    if item and item.goto_path and item.goto_cursor then
+      open("tabedit", item.goto_path, item.goto_cursor)
+      return
+    end
+
     if item and item.absolute_path then
       open("tabedit", item.absolute_path, translate_cursor_location(self, item))
     end
@@ -1156,6 +1169,12 @@ M.n_split_open = function(self)
   return function()
     local item = self.buffer.ui:get_item_under_cursor()
 
+    -- Goto PLUGIN (TODO, etc...)
+    if item and item.goto_path and item.goto_cursor then
+      open("split", item.goto_path, item.goto_cursor)
+      return
+    end
+
     if item and item.absolute_path then
       open("split", item.absolute_path, translate_cursor_location(self, item))
     end
@@ -1166,6 +1185,12 @@ end
 M.n_vertical_split_open = function(self)
   return function()
     local item = self.buffer.ui:get_item_under_cursor()
+
+    -- Goto PLUGIN (TODO, etc...)
+    if item and item.goto_path and item.goto_cursor then
+      open("vsplit", item.goto_path, item.goto_cursor)
+      return
+    end
 
     if item and item.absolute_path then
       open("vsplit", item.absolute_path, translate_cursor_location(self, item))

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -120,6 +120,11 @@ end
 ---@field folded boolean Whether or not this section should be open or closed by default
 ---@field hidden boolean Whether or not this section should be shown
 
+---@class NeogitTodoConfigSection A section to show in the Neogit Status buffer, e.g. Staged/Unstaged/Untracked
+---@field folded boolean Whether or not this section should be open or closed by default
+---@field hidden boolean Whether or not this section should be shown
+---@field keywords { [string]: string } Dictionary of keywords to search for (key) and the highlight to apply (value)
+
 ---@class NeogitConfigSections
 ---@field untracked NeogitConfigSection|nil
 ---@field unstaged NeogitConfigSection|nil
@@ -133,6 +138,7 @@ end
 ---@field rebase NeogitConfigSection|nil
 ---@field sequencer NeogitConfigSection|nil
 ---@field bisect NeogitConfigSection|nil
+---@field todo NeogitTodoConfigSection|nil
 
 ---@class HighlightOptions
 ---@field italic?     boolean
@@ -514,6 +520,16 @@ function M.get_default_values()
         folded = true,
         hidden = false,
       },
+      todo = {
+        folded = true,
+        hidden = false,
+        keywords = {
+          ["TODO"] = "NeogitGraphBoldBlue",
+          ["NOTE"] = "NeogitGraphBoldGreen",
+          ["FIXME"] = "NeogitGraphBoldRed",
+          ["HACK"] = "NeogitGraphBoldOrange",
+        },
+      },
     },
     ignored_settings = {
       "NeogitPushPopup--force-with-lease",
@@ -794,6 +810,10 @@ function M.validate_config()
       validate_type(section, "section." .. section_name, "table")
       validate_type(section.folded, string.format("section.%s.folded", section_name), "boolean")
       validate_type(section.hidden, string.format("section.%s.hidden", section_name), "boolean")
+
+      if section_name == "todo" then
+        validate_type(section.keywords, "section.todo.keywords", "table")
+      end
     end
   end
 
@@ -1212,6 +1232,10 @@ function M.setup(opts)
         end
       end
     end
+  end
+
+  if type(opts.sections.todo.keywords) == "table" then
+    M.values.sections.todo.keywords = opts.sections.todo.keywords
   end
 
   M.values = vim.tbl_deep_extend("force", M.values, opts)

--- a/lua/neogit/lib/collection.lua
+++ b/lua/neogit/lib/collection.lua
@@ -68,6 +68,17 @@ function M.find(tbl, func)
   return nil
 end
 
+function M.group_by(tbl, key)
+  local result = {}
+  for _, item in ipairs(tbl) do
+    if not result[item[key]] then
+      result[item[key]] = {}
+    end
+    table.insert(result[item[key]], item)
+  end
+  return result
+end
+
 return setmetatable(M, {
   __call = function(_, tbl)
     return M.new(tbl)

--- a/lua/neogit/lib/ui/renderer.lua
+++ b/lua/neogit/lib/ui/renderer.lua
@@ -168,11 +168,11 @@ function Renderer:_render_child(child)
 
   child.position.row_end = #self.buffer.line
 
-  if child.options.section then
+  if child.options and child.options.section then
     self.index:add_section(child.options.section, child.position.row_start, child.position.row_end)
   end
 
-  if child.options.item then
+  if child.options and child.options.item then
     child.options.item.folded = child.options.folded
     self.index:add_item(child.options.item, child.position.row_start, child.position.row_end)
   end
@@ -182,7 +182,7 @@ function Renderer:_render_child(child)
     table.insert(self.buffer.line_highlight, { #self.buffer.line - 1, line_hl })
   end
 
-  if child.options.virtual_text then
+  if child.options and child.options.virtual_text then
     table.insert(self.buffer.extmark, {
       self.namespace,
       #self.buffer.line - 1,


### PR DESCRIPTION
- Adds about 800ms to the load time of the buffer, would scale poorly with bigger projects
- Needs either some caching mechanism, or to run async with the repo state refreshings
- Not 100% sold on the UI yet
- This could be the foundation for a plugin system, allowing more custom sections to be added for users