### PR TITLE
fix: git-absorb getting stuck

### DIFF
--- a/lua/neogit/popups/commit/actions.lua
+++ b/lua/neogit/popups/commit/actions.lua
@@ -182,7 +182,7 @@ function M.absorb(popup)
     return
   end
 
-  git.cli.absorb.verbose.base(commit).and_rebase.call()
+  git.cli.absorb.verbose.base(commit).env({ GIT_SEQUENCE_EDITOR = ":" }).and_rebase.call()
 end
 
 return M


### PR DESCRIPTION
This fixes neogit hanging forever when using git absorb as reported in the issue #1564

Closes #1564 