### PR TITLE
Change: config.process_spinner is now `false` by default. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ neogit.setup {
   -- Show relative date by default. When set, use `strftime` to display dates
   commit_date_format = nil,
   log_date_format = nil,
+  -- Show message with spinning animation when a git command is running.
+  process_spinner = false,
   -- Used to generate URL's for branch popup action "pull request".
   git_services = {
     ["github.com"] = "https://github.com/${owner}/${repository}/compare/${branch_name}?expand=1",

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -359,7 +359,7 @@ function M.get_default_values()
     graph_style = "ascii",
     commit_date_format = nil,
     log_date_format = nil,
-    process_spinner = vim.opt.cmdheight:get() > 0,
+    process_spinner = false,
     filewatcher = {
       enabled = true,
     },


### PR DESCRIPTION
issues with blinking cursors for users.