### PR TITLE
fix: empty buffer error on open buffer action

### DIFF
--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -72,11 +72,7 @@ local function translate_cursor_location(self, item)
 end
 
 local function open(type, path, cursor)
-  local command = ("silent! %s %s | %s"):format(
-    type,
-    fn.fnameescape(path),
-    cursor and cursor[1] or "1"
-  )
+  local command = ("silent! %s %s | %s"):format(type, fn.fnameescape(path), cursor and cursor[1] or "1")
 
   logger.debug("[Status - Open] '" .. command .. "'")
 

--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -72,11 +72,17 @@ local function translate_cursor_location(self, item)
 end
 
 local function open(type, path, cursor)
-  local command = ("silent! %s %s | %s | redraw! | norm! zz"):format(
+  local command = ("silent! %s %s | %s"):format(
     type,
     fn.fnameescape(path),
     cursor and cursor[1] or "1"
   )
+
+  logger.debug("[Status - Open] '" .. command .. "'")
+
+  vim.cmd(command)
+
+  command = "redraw! | norm! zz"
 
   logger.debug("[Status - Open] '" .. command .. "'")
 


### PR DESCRIPTION
When attempting to open a newly tracked folder in the status window an `Empty buffer` error is raised:

```
Error executing vim.schedule lua callback: vim/_editor.lua:0: nvim_exec2(): Vim(print):E749: Empty buffer
stack traceback:
        [C]: in function 'nvim_exec2'
        vim/_editor.lua: in function 'cmd'
        ...e/nvim/lazy/neogit/lua/neogit/buffers/status/actions.lua:83: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

After manually clearing the above error the folder gets opened in whatever file explorer you are using (I'm using Oil.nvim, netrw doesn't seem to have this problem)

I debugged the issue and found that the use of `redraw! | norm! zz` is causing this issue. This might be because of the way Oil creates its file explorer buffer. 

To fix this issue I updated the code to just run the `redraw! | norm! zz` command after we have opened the buffer. This shouldn't cause any breaking issues as the functionality of the `open` function is still the same.