### PR TITLE
feat: add snacks.picker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here's an example spec for [Lazy](https://github.com/folke/lazy.nvim), but you'r
     "nvim-telescope/telescope.nvim", -- optional
     "ibhagwan/fzf-lua",              -- optional
     "echasnovski/mini.pick",         -- optional
+    "folke/snacks.nvim",             -- optional
   },
   config = true
 }
@@ -246,6 +247,11 @@ neogit.setup {
     -- is also selected then telescope is used instead
     -- Requires you to have `echasnovski/mini.pick` installed.
     mini_pick = nil,
+
+    -- If enabled, uses snacks.picker for menu selection. If the telescope integration
+    -- is also selected then telescope is used instead
+    -- Requires you to have `folke/snacks.nvim` installed.
+    snacks = nil,
   },
   sections = {
     -- Reverting/Cherry Picking

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -263,6 +263,11 @@ to Neovim users.
         -- is also selected then telescope is used instead
         -- Requires you to have `echasnovski/mini.pick` installed.
         mini_pick = nil,
+
+        -- If enabled, uses snacks.picker for menu selection. If the telescope integration
+        -- is also selected then telescope is used instead
+        -- Requires you to have `folke/snacks.nvim` installed.
+        snacks = nil,
     },
     sections = {
         -- Reverting/Cherry Picking

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -340,7 +340,7 @@ end
 ---@field preview_buffer? NeogitConfigPopup Preview options
 ---@field popup? NeogitConfigPopup Set the default way of opening popups
 ---@field signs? NeogitConfigSigns Signs used for toggled regions
----@field integrations? { diffview: boolean, telescope: boolean, fzf_lua: boolean, mini_pick: boolean } Which integrations to enable
+---@field integrations? { diffview: boolean, telescope: boolean, fzf_lua: boolean, mini_pick: boolean, snacks: boolean } Which integrations to enable
 ---@field sections? NeogitConfigSections
 ---@field ignored_settings? string[] Settings to never persist, format: "Filetype--cli-value", i.e. "NeogitCommitPopup--author"
 ---@field mappings? NeogitConfigMappings
@@ -469,6 +469,7 @@ function M.get_default_values()
       diffview = nil,
       fzf_lua = nil,
       mini_pick = nil,
+      snacks = nil,
     },
     sections = {
       sequencer = {
@@ -775,7 +776,7 @@ function M.validate_config()
   end
 
   local function validate_integrations()
-    local valid_integrations = { "diffview", "telescope", "fzf_lua", "mini_pick" }
+    local valid_integrations = { "diffview", "telescope", "fzf_lua", "mini_pick", "snacks" }
     if not validate_type(config.integrations, "integrations", "table") or #config.integrations == 0 then
       return
     end


### PR DESCRIPTION
Add integration support for the new picker `snacks.picker`, which may become the default picker in future LazyVim releases.

I have tested this integration with both single selection (for branch checkout) and multiple selection (for resetting multiple files).

https://github.com/user-attachments/assets/28dc75c1-a059-4523-9929-97349f85df95

