### PR TITLE
Refs view: branch deletion

### DIFF
--- a/lua/neogit/buffers/refs_view/init.lua
+++ b/lua/neogit/buffers/refs_view/init.lua
@@ -61,6 +61,22 @@ function M.delete_branch(ref)
   end
 end
 
+function M.delete_branches(refs)
+  if #refs > 0 then
+    local input = require("neogit.lib.input")
+    local names = {}
+    for _, ref in ipairs(refs) do
+      if ref.unambiguous_name then
+        table.insert(names, ref.unambiguous_name)
+      end
+    end
+    local message = ("Delete %s branch(es)?"):format(#names)
+    if input.get_permission(message) then
+      git.branch.delete_many(names)
+    end
+  end
+end
+
 --- Opens the RefsViewBuffer
 function M:open()
   if M.is_open() then
@@ -120,6 +136,9 @@ function M:open()
             item = { name = items },
           }
         end),
+        [mapping["DeleteBranch"]] = function()
+          M.delete_branches(self.buffer.ui:get_refs_under_cursor())
+        end,
       },
       n = {
         [popups.mapping_for("CherryPickPopup")] = popups.open("cherry_pick", function(p)

--- a/lua/neogit/buffers/refs_view/init.lua
+++ b/lua/neogit/buffers/refs_view/init.lua
@@ -50,13 +50,20 @@ function M.is_open()
   return (M.instance and M.instance.buffer and M.instance.buffer:is_visible()) == true
 end
 
+function M._do_delete(ref)
+  if not ref.remote then
+    git.branch.delete(ref.unambiguous_name)
+  else
+    git.cli.push.remote(ref.remote).delete.to(ref.name).call()
+  end
+end
+
 function M.delete_branch(ref)
-  local name = ref and ref.unambiguous_name
-  if name then
+  if ref then
     local input = require("neogit.lib.input")
-    local message = ("Delete branch: '%s'?"):format(name)
+    local message = ("Delete branch: '%s'?"):format(ref.unambiguous_name)
     if input.get_permission(message) then
-      git.branch.delete(name)
+      M._do_delete(ref)
     end
   end
 end
@@ -64,15 +71,11 @@ end
 function M.delete_branches(refs)
   if #refs > 0 then
     local input = require("neogit.lib.input")
-    local names = {}
-    for _, ref in ipairs(refs) do
-      if ref.unambiguous_name then
-        table.insert(names, ref.unambiguous_name)
-      end
-    end
-    local message = ("Delete %s branch(es)?"):format(#names)
+    local message = ("Delete %s branch(es)?"):format(#refs)
     if input.get_permission(message) then
-      git.branch.delete_many(names)
+      for _, ref in ipairs(refs) do
+        M._do_delete(ref)
+      end
     end
   end
 end

--- a/lua/neogit/buffers/refs_view/init.lua
+++ b/lua/neogit/buffers/refs_view/init.lua
@@ -3,6 +3,7 @@ local config = require("neogit.config")
 local ui = require("neogit.buffers.refs_view.ui")
 local popups = require("neogit.popups")
 local status_maps = require("neogit.config").get_reversed_status_maps()
+local mapping = config.get_reversed_refs_view_maps()
 local CommitViewBuffer = require("neogit.buffers.commit_view")
 local Watcher = require("neogit.watcher")
 local logger = require("neogit.logger")
@@ -47,6 +48,17 @@ end
 ---@return boolean
 function M.is_open()
   return (M.instance and M.instance.buffer and M.instance.buffer:is_visible()) == true
+end
+
+function M.delete_branch(ref)
+  local name = ref and ref.unambiguous_name
+  if name then
+    local input = require("neogit.lib.input")
+    local message = ("Delete branch: '%s'?"):format(name)
+    if input.get_permission(message) then
+      git.branch.delete(name)
+    end
+  end
 end
 
 --- Opens the RefsViewBuffer
@@ -121,6 +133,9 @@ function M:open()
             suggested_branch_name = ref and ref.name,
           }
         end),
+        [mapping["DeleteBranch"]] = function()
+          M.delete_branch(self.buffer.ui:get_ref_under_cursor())
+        end,
         [popups.mapping_for("CommitPopup")] = popups.open("commit", function(p)
           p { commit = self.buffer.ui:get_commits_in_selection()[1] }
         end),

--- a/lua/neogit/buffers/refs_view/init.lua
+++ b/lua/neogit/buffers/refs_view/init.lua
@@ -141,6 +141,7 @@ function M:open()
         end),
         [mapping["DeleteBranch"]] = function()
           M.delete_branches(self.buffer.ui:get_refs_under_cursor())
+          self:redraw()
         end,
       },
       n = {
@@ -157,6 +158,7 @@ function M:open()
         end),
         [mapping["DeleteBranch"]] = function()
           M.delete_branch(self.buffer.ui:get_ref_under_cursor())
+          self:redraw()
         end,
         [popups.mapping_for("CommitPopup")] = popups.open("commit", function(p)
           p { commit = self.buffer.ui:get_commits_in_selection()[1] }

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -61,6 +61,11 @@ end
 function M.get_reversed_commit_editor_maps_I()
   return get_reversed_maps("commit_editor_I")
 end
+---
+---@return table<string, string[]>
+function M.get_reversed_refs_view_maps()
+  return get_reversed_maps("refs_view")
+end
 
 ---@param set string
 ---@return table<string, string[]>
@@ -278,6 +283,11 @@ end
 ---| "Abort"
 ---| false
 ---| fun()
+---
+---@alias NeogitConfigMappingsRefsView
+---| "DeleteBranch"
+---| false
+---| fun()
 
 ---@alias NeogitGraphStyle
 ---| "ascii"
@@ -300,6 +310,7 @@ end
 ---@field rebase_editor_I? { [string]: NeogitConfigMappingsRebaseEditor_I } A dictionary that uses Rebase editor commands to set a single keybind
 ---@field commit_editor? { [string]: NeogitConfigMappingsCommitEditor } A dictionary that uses Commit editor commands to set a single keybind
 ---@field commit_editor_I? { [string]: NeogitConfigMappingsCommitEditor_I } A dictionary that uses Commit editor commands to set a single keybind
+---@field refs_view? { [string]: NeogitConfigMappingsRefsView } A dictionary that uses Refs view editor commands to set a single keybind
 
 ---@class NeogitConfig Neogit configuration settings
 ---@field filewatcher? NeogitFilewatcherConfig Values for filewatcher
@@ -582,6 +593,9 @@ function M.get_default_values()
         ["<ScrollWheelRight>"] = "NOP",
         ["<LeftMouse>"] = "MouseClick",
         ["<2-LeftMouse>"] = "NOP",
+      },
+      refs_view = {
+        ["x"] = "DeleteBranch",
       },
       popup = {
         ["?"] = "HelpPopup",
@@ -1211,7 +1225,8 @@ function M.setup(opts)
   end
 
   if opts.use_default_keymaps == false then
-    M.values.mappings = { status = {}, popup = {}, finder = {}, commit_editor = {}, rebase_editor = {} }
+    M.values.mappings =
+      { status = {}, popup = {}, finder = {}, commit_editor = {}, rebase_editor = {}, refs_view = {} }
   else
     -- Clear our any "false" user mappings from defaults
     for section, maps in pairs(opts.mappings or {}) do

--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -183,38 +183,6 @@ function M.delete(name)
 
   return result and result.code == 0 or false
 end
----
----@param names string[]
----@return boolean
-function M.delete_many(names)
-  local input = require("neogit.lib.input")
-
-  local unmerged = 0
-  for _, name in ipairs(names) do
-    if M.is_unmerged(name) then
-      unmerged = unmerged + 1
-    end
-  end
-
-  if unmerged > 0 then
-    local message = ("%d branch(es) contain unmerged commits! Are you sure you want to delete them?"):format(
-      unmerged
-    )
-    if not input.get_permission(message) then
-      return false
-    end
-  end
-
-  local result
-  for _, name in ipairs(names) do
-    local result_single = git.cli.branch.delete.force.name(name).call { await = true }
-    if result_single.code ~= 0 then
-      return result and result.code == 0 or false
-    end
-  end
-
-  return true
-end
 
 ---Returns current branch name, or nil if detached HEAD
 ---@return string|nil

--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -183,6 +183,38 @@ function M.delete(name)
 
   return result and result.code == 0 or false
 end
+---
+---@param names string[]
+---@return boolean
+function M.delete_many(names)
+  local input = require("neogit.lib.input")
+
+  local unmerged = 0
+  for _, name in ipairs(names) do
+    if M.is_unmerged(name) then
+      unmerged = unmerged + 1
+    end
+  end
+
+  if unmerged > 0 then
+    local message = ("%d branch(es) contain unmerged commits! Are you sure you want to delete them?"):format(
+      unmerged
+    )
+    if not input.get_permission(message) then
+      return false
+    end
+  end
+
+  local result
+  for _, name in ipairs(names) do
+    local result_single = git.cli.branch.delete.force.name(name).call { await = true }
+    if result_single.code ~= 0 then
+      return result and result.code == 0 or false
+    end
+  end
+
+  return true
+end
 
 ---Returns current branch name, or nil if detached HEAD
 ---@return string|nil

--- a/lua/neogit/lib/ui/init.lua
+++ b/lua/neogit/lib/ui/init.lua
@@ -349,6 +349,26 @@ function Ui:get_ref_under_cursor()
 
   return component and component.options.ref
 end
+---
+---@return ParsedRef[]
+function Ui:get_refs_under_cursor()
+  local range = { vim.fn.getpos("v")[2], vim.fn.getpos(".")[2] }
+  table.sort(range)
+  local start, stop = unpack(range)
+
+  local refs = {}
+  for i = start, stop do
+    local component = self:_find_component_by_index(i, function(node)
+      return node.options.ref ~= nil
+    end)
+
+    if component then
+      table.insert(refs, 1, component.options.ref)
+    end
+  end
+
+  return util.deduplicate(refs)
+end
 
 ---@return string|nil
 function Ui:get_yankable_under_cursor()


### PR DESCRIPTION
Hi there! A small QoL improvement for the refs view from magit. I suspect I may have missed an edge case or two, but it is still pretty handy for bulk-deletion when you have lots of old branches hanging round.

- Allows deleting a branch from the refs view more easily with a direct bind ('x' by default), similar to magit.
- Allows deleting multiple branches simultaneously with a visual selection which makes cleaning up lots of branches much simpler.

I wasn't entirely sure if making a new sub-section `refs_view` in the mappings was the ideal option as it didn't exist already and most of the other mappings it uses open other popups, but that's what I went for - happy to amend if it makes sense to do it a different way.

https://github.com/user-attachments/assets/4cf88f33-ed28-4507-b911-11f6484304a0

