### PR TITLE
fix: pushRemote.branch string extraction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,9 @@ See [the test documentation for more details](./tests/README.md).
 Additionally, linting is enforced using `selene` to catch common errors, most of which are also caught by
 `lua-language-server`.
 
-```sh make lint ```
+```sh
+make lint
+```
 
 ### Formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ See [the test documentation for more details](./tests/README.md).
 ### Linting
 
 Additionally, linting is enforced using `selene` to catch common errors, most of which are also caught by
-`lua-language-server`.
+`lua-language-server`. Source code spell checking is done via `typos`.
 
 ```sh
 make lint

--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -424,7 +424,7 @@ local function update_branch_information(state)
 
     local pushRemote = git.branch.pushRemote_ref()
     if pushRemote and not status.detached then
-      local remote, branch = unpack(vim.split(pushRemote, "/"))
+      local remote, branch = pushRemote:match("([^/]+)/(.+)")
       state.pushRemote.ref = pushRemote
       state.pushRemote.remote = remote
       state.pushRemote.branch = branch


### PR DESCRIPTION
The current use of `unpack` and `vim.split` to extract the branch name of an upstream ref fails to properly handle branch names containing forward slash (`/`) symbols. In particular, it discards the branch name's portion including and following the first occurrence of a `/` symbol.

For example:
* `pushRemote.ref == "origin/branch/name"`
* `pushRemote.branch (expected) == "branch/name"`
* `pushRemote.branch (actual) == "branch"`

UI example:
<img width="238" alt="Screenshot 2025-02-16 at 23 04 38" src="https://github.com/user-attachments/assets/6f888611-aa1b-4f6f-99f0-6d9f191c6b80" />
<img width="385" alt="Screenshot 2025-02-16 at 23 04 28" src="https://github.com/user-attachments/assets/f08bf8a6-6771-4005-84ce-2d2ea94dae31" />

This PR replaces this usage of `unpack` and `vim.split` with a regex match that properly handles branch names containing `/` symbols.