### PR TITLE
Only try to detach UFO if it is loaded

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -388,10 +388,12 @@ function Buffer:show()
   end
 
   -- Workaround UFO getting folds wrong.
-  local ok, ufo = pcall(require, "ufo")
-  if ok and type(ufo.detach) == "function" then
-    logger.debug("[BUFFER:" .. self.handle .. "] Disabling UFO for buffer")
-    ufo.detach(self.handle)
+  if package.loaded["nvim-ufo"] then
+    local ok, ufo = pcall(require, "ufo")
+    if ok and type(ufo.detach) == "function" then
+      logger.debug("[BUFFER:" .. self.handle .. "] Disabling UFO for buffer")
+      ufo.detach(self.handle)
+    end
   end
 
   self.win_handle = win


### PR DESCRIPTION
Without this check, it could be that `ufo.setup()` is not called before `ufo.detach()`, (for example if UFO is lazy-loaded with `lazy.nvim` which breaks UFO's internal assumptions, and causes an error.

Example of error:
```
Error executing Lua callback: .../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:48: Vim:Error executing Lua callback: ...gilice/.local/share/nvim/lazy/nvim-ufo/lua/ufo/bufmanager.lua:111: attempt to index field 'bufDetachSet' (a nil value)
stack traceback:
	...gilice/.local/share/nvim/lazy/nvim-ufo/lua/ufo/bufmanager.lua:111: in function 'detach'
	/home/gilice/.local/share/nvim/lazy/nvim-ufo/lua/ufo/main.lua:174: in function 'detach'
	/home/gilice/.local/share/nvim/lazy/nvim-ufo/lua/ufo.lua:99: in function 'detach'
	.../.local/share/nvim/lazy/neogit/lua/neogit/lib/buffer.lua:396: in function 'show'
	.../.local/share/nvim/lazy/neogit/lua/neogit/lib/buffer.lua:699: in function 'create'
	...hare/nvim/lazy/neogit/lua/neogit/buffers/status/init.lua:98: in function 'open'
	/home/gilice/.local/share/nvim/lazy/neogit/lua/neogit.lua:114: in function 'open_status_buffer'
	/home/gilice/.local/share/nvim/lazy/neogit/lua/neogit.lua:175: in function 'open'
	/home/gilice/.local/share/nvim/lazy/neogit/plugin/neogit.lua:5: in function </home/gilice/.local/share/nvim/lazy/neogit/plugin/neogit.lua:3>
	[C]: in function 'cmd'
	.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:48: in function <.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:16>
stack traceback:
	[C]: in function 'cmd'
	.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:48: in function <.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:16>


```