### PR TITLE
Only detach UFO if it is loaded, 2nd try

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -388,10 +388,12 @@ function Buffer:show()
   end
 
   -- Workaround UFO getting folds wrong.
-  local ok, ufo = pcall(require, "ufo")
-  if ok and type(ufo.detach) == "function" then
-    logger.debug("[BUFFER:" .. self.handle .. "] Disabling UFO for buffer")
-    ufo.detach(self.handle)
+  if package.loaded["ufo"] then
+    local ok, ufo = pcall(require, "ufo")
+    if ok and type(ufo.detach) == "function" then
+      logger.debug("[BUFFER:" .. self.handle .. "] Disabling UFO for buffer")
+      ufo.detach(self.handle)
+    end
   end
 
   self.win_handle = win


### PR DESCRIPTION
Fixes cd793fb9d37ad605b8699d8482aeba8a6b17749f (pr #1662).
Fixes https://github.com/NeogitOrg/neogit/issues/1665.

Sorry for my mistake, and thank you @jedrzejboczar for pointing out I should check for `ufo` instead of `nvim-ufo`.

Fun anecdote: I had been running the correct code in my neovim config, because I ran into the same issue (checking for the wrong package name), but I forgot to copy it over to my fork of neogit, before making the PR.

I'd still like this code to be included, if possible, in Neogit, to fix the original issue I was having.