### PR TITLE
Error notifications when pulling

### DIFF
--- a/lua/neogit/popups/pull/actions.lua
+++ b/lua/neogit/popups/pull/actions.lua
@@ -32,6 +32,11 @@ local function pull_from(args, remote, branch, opts)
     vim.api.nvim_exec_autocmds("User", { pattern = "NeogitPullComplete", modeline = false })
   else
     logger.error("Failed to pull from " .. name)
+    notification.error("Failed to pull from " .. name, { dismiss = true })
+    if res.code == 128 then
+      notification.info(table.concat(res.stdout, "\n"))
+      return
+    end
   end
 end
 


### PR DESCRIPTION
Presently, there are no notifications when there are errors when pulling. This commit adds them.

I'm not sure how you want those to look like, so I've added what feel like sensible defaults. Please feel free to change those.
