### PR TITLE
fix: show 3 way diff with diff worktree when there are conflicts

### DIFF
--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -132,7 +132,7 @@ function M.open(section_name, item_name, opts)
     view = dv_lib.diffview_open(dv_utils.tbl_pack(item_name .. "^!"))
   elseif section_name == "conflict" and item_name then
     view = dv_lib.diffview_open(dv_utils.tbl_pack("--selected-file=" .. item_name))
-  elseif section_name == "conflict" and not item_name then
+  elseif (section_name == "conflict" or section_name == "worktree") and not item_name then
     view = dv_lib.diffview_open()
   elseif section_name ~= nil then
     view = get_local_diff_view(section_name, item_name, opts)


### PR DESCRIPTION
https://github.com/NeogitOrg/neogit/issues/1645 shows that 3 way (also 4 way) diff is no longer opened with diff worktree (`dw` shortcut).

With [a recent change](https://github.com/NeogitOrg/neogit/commit/3f098789c6baaf24c81eb6428444d9fa6364353a) opening diff worktree was changed to use `get_local_diff_view`, as the section_name is now set to "worktree".

But I think the old behaviour of using `dv_lib.diffview_open` is actually preferred, as that will show the 3 (or 4) way diff view for conflicts.