### PR TITLE
Fix: Staging conflicted files and diffview

### DIFF
--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -1062,7 +1062,7 @@ M.n_stage = function(self)
       end
 
       if selection.item and selection.item.mode == "UU" then
-        if config.check_integration("diffview") then
+        if config.check_integration("diffview") and git.merge.is_conflicted(selection.item.name) then
           require("neogit.integrations.diffview").open("conflict", selection.item.name, {
             on_close = {
               handle = self.buffer.handle,


### PR DESCRIPTION
This is an addition to https://github.com/NeogitOrg/neogit/pull/1675 (which is in the first commit https://github.com/NeogitOrg/neogit/pull/1685/commits/b754b343b7cab4078c8033bb36dbaeb706a5edd6 in my PR) and a quick solution to https://github.com/NeogitOrg/neogit/issues/1621. I think it is reasonable to check for conflicts in the selected file before launching diffview. This is all my addition does.

**Update**: Now that https://github.com/NeogitOrg/neogit/pull/1675 is merged i want to emphasize that from my observations my small addition is still needed to fix https://github.com/NeogitOrg/neogit/issues/1621 completely. Also for the cases where conflicts and resolving happen during a rebase or cherry-pick. With only https://github.com/NeogitOrg/neogit/pull/1675 applied the problem of hitting `s` on already resolved conflicts did still open `diffview` and only after closing it once again the selected file was staged.