### PR TITLE
add option for persistent recent section

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ neogit.setup {
     recent = {
       folded = true,
       hidden = false,
+      always = false,
     },
     rebase = {
       folded = true,

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -307,6 +307,7 @@ to Neovim users.
         recent = {
         folded = true,
         hidden = false,
+        always = false,
         },
         rebase = {
         folded = true,

--- a/lua/neogit/buffers/status/ui.lua
+++ b/lua/neogit/buffers/status/ui.lua
@@ -517,6 +517,8 @@ function M.Status(state, config)
 
   local show_recent = #state.recent.items > 0
     and not config.sections.recent.hidden
+    and (config.sections.recent.always or not show_upstream_unmerged)
+
 
   return {
     List {
@@ -668,7 +670,7 @@ function M.Status(state, config)
           folded = config.sections.unmerged_pushRemote.folded,
           name = "pushRemote_unmerged",
         },
-        not show_upstream_unmerged and show_recent and Section {
+        show_recent and Section {
           title = SectionTitle { title = "Recent Commits", highlight = "NeogitRecentcommits" },
           count = false,
           render = SectionItemCommit,

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -516,6 +516,7 @@ function M.get_default_values()
       recent = {
         folded = true,
         hidden = false,
+        always = false,
       },
       rebase = {
         folded = true,

--- a/tests/specs/neogit/config_spec.lua
+++ b/tests/specs/neogit/config_spec.lua
@@ -404,6 +404,16 @@ describe("Neogit config", function()
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
       end)
 
+      it("should return invalid when sections.recent.hidden isn't a boolean", function()
+        config.values.sections.recent.hidden = "not a boolean"
+        assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when sections.recent.always isn't a boolean", function()
+        config.values.sections.recent.always = "not a boolean"
+        assert.False(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
+      end)
+
       it("should return invalid when sections.recent.folded isn't a boolean", function()
         config.values.sections.recent.folded = "not a boolean"
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)


### PR DESCRIPTION
fixes #1687 

This PR adds a new option `config.sections.recent.always`, which defaults to `false`. This keeps the current behavior which only shows the recent section if there is no unmerged commits. which looks like this

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f94aadb9-cc32-42d0-a3f0-0bcb9e6f0c66" />

Setting this option to `true` will always show the recent section. which looks like this

<img width="300" alt="image" src="https://github.com/user-attachments/assets/eabfbf90-84ab-4038-9052-6fbe7ade2e0e" />


