### PR TITLE
Add support for disabling commit signing on rebase

### DIFF
--- a/lua/neogit/popups/rebase/init.lua
+++ b/lua/neogit/popups/rebase/init.lua
@@ -30,7 +30,15 @@ function M.create(env)
     :switch_if(not in_rebase, "A", "autostash", "Autostash", { enabled = true })
     :switch_if(not in_rebase, "i", "interactive", "Interactive")
     :switch_if(not in_rebase, "h", "no-verify", "Disable hooks")
-    :option_if(not in_rebase, "S", "gpg-sign", "", "Sign using gpg", { key_prefix = "-" })
+    :option_if(
+      not in_rebase,
+      "S",
+      "gpg-sign",
+      "",
+      "Sign using gpg",
+      { key_prefix = "-", incompatible = { "no-gpg-sign" } }
+    )
+    :switch_if(not in_rebase, "n", "no-gpg-sign", "Disable GPG signing", { incompatible = { "gpg-sign" } })
     :group_heading_if(not in_rebase, "Rebase " .. (branch and (branch .. " ") or "") .. "onto")
     :action_if(not in_rebase, "p", git.branch.pushRemote_label(), actions.onto_pushRemote)
     :action_if(not in_rebase, "u", git.branch.upstream_label(), actions.onto_upstream)

--- a/spec/popups/rebase_popup_spec.rb
+++ b/spec/popups/rebase_popup_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Rebase Popup", :git, :nvim, :popup do # rubocop:disable RSpec/Em
       " -i Interactive (--interactive)                                                 ",
       " -h Disable hooks (--no-verify)                                                 ",
       " -S Sign using gpg (--gpg-sign=)                                                ",
+      " -n Disable GPG signing (--no-gpg-sign)                                         ",
       "                                                                                ",
       " Rebase master onto              Rebase                                         ",
       " p pushRemote, setting that      i interactively   m to modify a commit         ",


### PR DESCRIPTION
Current version of Neogit allows users to enable commit signing if they have it globally disabled. However, there is no way to explicitly disable it if it has been enabled globally.

My personal use case for this is that I generally sign all of my commits, but occasionally when I'm doing local rebase of big branches, I want to switch the GPG signing off.