### PR TITLE
fix: `\` is not correctly escaped on MinGW

### DIFF
--- a/lua/neogit/client.lua
+++ b/lua/neogit/client.lua
@@ -65,11 +65,7 @@ function M.client(opts)
   logger.debug(("[CLIENT] Client address: %s"):format(client))
 
   local lua_cmd =
-    fmt('lua require("neogit.client").editor("%s", "%s", %s)', file_target, client, opts.show_diff)
-
-  if vim.uv.os_uname().sysname == "Windows_NT" then
-    lua_cmd = lua_cmd:gsub("\\", "/")
-  end
+    fmt('lua require("neogit.client").editor(%q, %q, %s)', file_target, client, opts.show_diff)
 
   local rpc_server = RPC.create_connection(nvim_server)
   rpc_server:send_cmd(lua_cmd)

--- a/lua/neogit/client.lua
+++ b/lua/neogit/client.lua
@@ -64,9 +64,7 @@ function M.client(opts)
   local client = fn.serverstart()
   logger.debug(("[CLIENT] Client address: %s"):format(client))
 
-  local lua_cmd =
-    fmt('lua require("neogit.client").editor(%q, %q, %s)', file_target, client, opts.show_diff)
-
+  local lua_cmd = fmt('lua require("neogit.client").editor(%q, %q, %s)', file_target, client, opts.show_diff)
   local rpc_server = RPC.create_connection(nvim_server)
   rpc_server:send_cmd(lua_cmd)
 end


### PR DESCRIPTION
On MinGW `vim.uv.os_uname().sysname` returns something with `MINGW`. Instead use Luas formatting option [`%q` to correctly escape any character](https://www.lua.org/manual/5.1/manual.html#pdf-string.format).