### PR TITLE
fix: set border=none for header text explicitly

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -623,6 +623,7 @@ function Buffer:set_header(text, scroll)
     focusable = false,
     style = "minimal",
     noautocmd = true,
+    border = "none",
   })
   vim.wo[winid].wrap = false
   vim.wo[winid].winhl = "NormalFloat:NeogitFloatHeader"


### PR DESCRIPTION
This is only noticeable when a user sets `vim.o.winborder` to a custom value. Without the border option explicitly provided, the header will inherit the border style from the global winborder option, overlapping some first lines in the log view.

Screenshots with `vim.o.winborder = "rounded"`:
* current settings:

![Screenshot_20250416_225754](https://github.com/user-attachments/assets/dc2e347b-02b9-49d5-9102-0463265d8f2e)

* after this PR (will be back to the expected behavior):

![Screenshot_20250416_225708](https://github.com/user-attachments/assets/26fea6dc-c466-4cb7-a8da-5d3d3dfcbb0b)