### PR TITLE
Add command to copy finder selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ neogit.setup {
       ["<down>"] = "Next",
       ["<up>"] = "Previous",
       ["<tab>"] = "InsertCompletion",
+      ["<c-y>"] = "CopySelection",
       ["<space>"] = "MultiselectToggleNext",
       ["<s-space>"] = "MultiselectTogglePrevious",
       ["<c-j>"] = "NOP",

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -393,6 +393,7 @@ The following mappings can all be customized via the setup function.
         ["<down>"]             = "Next",
         ["<up>"]               = "Previous",
         ["<tab>"]              = "InsertCompletion",
+        ["<c-y>"]              = "CopySelection",
         ["<space>"]            = "MultiselectToggleNext",
         ["<s-space>"]          = "MultiselectTogglePrevious",
         ["<c-j>"]              = "NOP",

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -185,6 +185,7 @@ end
 ---| "Close"
 ---| "Next"
 ---| "Previous"
+---| "CopySelection"
 ---| "MultiselectToggleNext"
 ---| "MultiselectTogglePrevious"
 ---| "InsertCompletion"
@@ -589,6 +590,7 @@ function M.get_default_values()
         ["<down>"] = "Next",
         ["<up>"] = "Previous",
         ["<tab>"] = "InsertCompletion",
+        ["<c-y>"] = "CopySelection",
         ["<space>"] = "MultiselectToggleNext",
         ["<s-space>"] = "MultiselectTogglePrevious",
         ["<c-j>"] = "NOP",

--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -12,7 +12,7 @@ end
 local copy_selection = function()
   local selection = require("telescope.actions.state").get_selected_entry()
   if selection ~= nil then
-    vim.cmd.let(("@+='%s'"):format(selection[1]))
+    vim.cmd.let(("@+=%q"):format(selection[1]))
   end
 end
 

--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -9,6 +9,13 @@ local function refocus_status_buffer()
   end
 end
 
+local copy_selection = function()
+  local selection = require("telescope.actions.state").get_selected_entry()
+  if selection ~= nil then
+    vim.cmd.let(("@+='%s'"):format(selection[1]))
+  end
+end
+
 local function telescope_mappings(on_select, allow_multi, refocus_status)
   local action_state = require("telescope.actions.state")
   local actions = require("telescope.actions")
@@ -85,6 +92,7 @@ local function telescope_mappings(on_select, allow_multi, refocus_status)
       ["InsertCompletion"] = completion_action,
       ["Next"] = actions.move_selection_next,
       ["Previous"] = actions.move_selection_previous,
+      ["CopySelection"] = copy_selection,
       ["NOP"] = actions.nop,
       ["MultiselectToggleNext"] = actions.toggle_selection + actions.move_selection_worse,
       ["MultiselectTogglePrevious"] = actions.toggle_selection + actions.move_selection_better,


### PR DESCRIPTION
I was looking for a convenient way to copy branch names and found #1520. However, the proposed solution does not allow copying other branch names than the current one or commit hashes.

I would love a shortcut that allows copying the selection from any finder.

# Todo
- [x] implement/test multi-select finders