### PR TITLE
feat: Add `commit_template` option

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -367,6 +367,7 @@ end
 ---@field mappings? NeogitConfigMappings
 ---@field notification_icon? string
 ---@field use_default_keymaps? boolean
+---@field commit_template? string
 ---@field highlight? HighlightOptions
 ---@field builders? { [string]: fun(builder: PopupBuilder) }
 
@@ -446,6 +447,7 @@ function M.get_default_values()
         ["?"] = "",
       },
     },
+    commit_template = "",
     commit_editor = {
       kind = "tab",
       show_staged_diff = true,

--- a/lua/neogit/popups/commit/actions.lua
+++ b/lua/neogit/popups/commit/actions.lua
@@ -7,6 +7,7 @@ local input = require("neogit.lib.input")
 local notification = require("neogit.lib.notification")
 local config = require("neogit.config")
 local a = require("plenary.async")
+local path = require("plenary.path")
 
 ---@param popup PopupData
 ---@return boolean
@@ -33,6 +34,16 @@ local function confirm_modifications()
 end
 
 local function do_commit(popup, cmd)
+  local template_path = config.values.commit_template
+  if template_path ~= "" then
+    local template_file = path:new(template_path)
+    if template_file:exists() then
+      cmd = cmd.args("--template=" .. template_file:absolute())
+    else
+      notification.warn("Commit template file does not exist: \n" .. template_path)
+    end
+  end
+
   client.wrap(cmd.arg_list(popup:get_arguments()), {
     autocmd = "NeogitCommitComplete",
     msg = {


### PR DESCRIPTION
Specify a valid file to be used as a template when commiting.