### PR TITLE
Fix: Focus issues in 'Diff for range' and Diffview integration

### DIFF
--- a/lua/neogit/popups/diff/actions.lua
+++ b/lua/neogit/popups/diff/actions.lua
@@ -74,7 +74,7 @@ end
 function M.stash(popup)
   popup:close()
 
-  local selected = FuzzyFinderBuffer.new(git.stash.list()):open_async()
+  local selected = FuzzyFinderBuffer.new(git.stash.list()):open_async{ refocus_status = false }
   if selected then
     diffview.open("stashes", selected)
   end
@@ -85,7 +85,7 @@ function M.commit(popup)
 
   local options = util.merge(git.refs.list_branches(), git.refs.list_tags(), git.refs.heads())
 
-  local selected = FuzzyFinderBuffer.new(options):open_async()
+  local selected = FuzzyFinderBuffer.new(options):open_async{ refocus_status = false }
   if selected then
     diffview.open("commit", selected)
   end

--- a/lua/neogit/popups/diff/actions.lua
+++ b/lua/neogit/popups/diff/actions.lua
@@ -29,7 +29,8 @@ function M.range(popup)
   )
 
   local range_from = FuzzyFinderBuffer.new(options):open_async {
-    prompt_prefix = "Diff for range from", refocus_status = false
+    prompt_prefix = "Diff for range from",
+    refocus_status = false,
   }
   if not range_from then
     return
@@ -74,7 +75,7 @@ end
 function M.stash(popup)
   popup:close()
 
-  local selected = FuzzyFinderBuffer.new(git.stash.list()):open_async{ refocus_status = false }
+  local selected = FuzzyFinderBuffer.new(git.stash.list()):open_async { refocus_status = false }
   if selected then
     diffview.open("stashes", selected)
   end
@@ -85,7 +86,7 @@ function M.commit(popup)
 
   local options = util.merge(git.refs.list_branches(), git.refs.list_tags(), git.refs.heads())
 
-  local selected = FuzzyFinderBuffer.new(options):open_async{ refocus_status = false }
+  local selected = FuzzyFinderBuffer.new(options):open_async { refocus_status = false }
   if selected then
     diffview.open("commit", selected)
   end

--- a/lua/neogit/popups/diff/actions.lua
+++ b/lua/neogit/popups/diff/actions.lua
@@ -28,13 +28,15 @@ function M.range(popup)
     )
   )
 
-  local range_from = FuzzyFinderBuffer.new(options):open_async { prompt_prefix = "Diff for range from" }
+  local range_from = FuzzyFinderBuffer.new(options):open_async {
+    prompt_prefix = "Diff for range from", refocus_status = false
+  }
   if not range_from then
     return
   end
 
   local range_to = FuzzyFinderBuffer.new(options)
-    :open_async { prompt_prefix = "Diff from " .. range_from .. " to" }
+    :open_async { prompt_prefix = "Diff from " .. range_from .. " to", refocus_status = false }
   if not range_to then
     return
   end


### PR DESCRIPTION
This PR addresses two focus-related issues encountered when using the 'Diff for range' functionality:

1.  **Popup Focus:** When selecting a range in the diff view, the first "Diff for range from>" prompt would work correctly, but the subsequent "Diff for range to>" prompt would not be focused.
2.  **Diffview Tab Focus:** After successfully entering both ranges and opening the diff in Diffview, focus would immediately switch back to the Neogit status tab, leaving the Diffview tab open but in the background.

**Solution:**

Both issues were resolved by setting `refocus_status = false` in the `FuzzyFinderBuffer:open_async` calls.

-   Adding `refocus_status = false` to the prompt for "Diff for range from>" fixed the focus issue for the subsequent "Diff for range to>" prompt.
-   Adding `refocus_status = false` to the prompt for "Diff from ... to>" fixed the issue where Diffview would lose focus immediately after opening.

**Environment:**
These issues were observed and tested on:
*   Neovim: v0.12.0-dev-441+gba1cc9e10c
*   Minimal plugins enabled:
    *   plenary.nvim
    *   diffview.nvim
    *   fzf-lua
