### PR TITLE
provide popup.close for actions

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -205,6 +205,7 @@ function M.action(popup, action, args)
         if fn then
           local action = function()
             fn {
+              close = function() end,
               state = { env = {} },
               get_arguments = function()
                 return args


### PR DESCRIPTION
Hi, im encounter problem with `neogit.action('diff', '...')` 
Actions calls `popup:close()` but `close` not present in table that neogit.action provide for action callback



my current workaround
```lua
local function openDiff()
    local ngitdp = require("neogit.popups.diff")
    local ngitdpa = require("neogit.popups.diff.actions")
    local pop = ngitdp.create()
    ngitdpa.worktree(pop)
end
``` 