### PR TITLE
prevent asking for an upstream if it's set

### DIFF
--- a/lua/neogit/popups/rebase/actions.lua
+++ b/lua/neogit/popups/rebase/actions.lua
@@ -31,7 +31,7 @@ function M.onto_pushRemote(popup)
 end
 
 function M.onto_upstream(popup)
-  local upstream = git.branch.upstream(git.branch.current())
+  local upstream = git.branch.upstream()
   if not upstream then
     upstream = FuzzyFinderBuffer.new(git.refs.list_branches()):open_async()
   end


### PR DESCRIPTION
Trying to rebase with upstream with a different name kept asking for an upstream even after it was set.