### PR TITLE
Add auto-fetch feature

### DIFF
--- a/lua/neogit.lua
+++ b/lua/neogit.lua
@@ -73,34 +73,6 @@ function M.setup(opts)
   signs.setup(config.values)
   state.setup(config.values)
   autocmds.setup()
-
-  if config.values.auto_fetch_enabled then
-    local git = require("neogit.lib.git")
-
-    if M.auto_fetch_timer then
-      M.auto_fetch_timer:close()
-    end
-
-    M.auto_fetch_timer = vim.uv.new_timer()
-    M.auto_fetch_timer:start(
-      config.values.auto_fetch_interval,
-      config.values.auto_fetch_interval,
-      vim.schedule_wrap(function()
-        if git.cli.is_inside_worktree(vim.uv.cwd()) then
-          git.fetch.fetch("--all")
-        end
-      end)
-    )
-
-    if config.values.auto_fetch_on_startup then
-      if git.cli.is_inside_worktree(vim.uv.cwd()) then
-        git.fetch.fetch("--all")
-      end
-    end
-  elseif M.auto_fetch_timer then
-    M.auto_fetch_timer:close()
-    M.auto_fetch_timer = nil
-  end
 end
 
 local function construct_opts(opts)

--- a/lua/neogit/autocmds.lua
+++ b/lua/neogit/autocmds.lua
@@ -7,6 +7,21 @@ function M.setup()
   local status_buffer = require("neogit.buffers.status")
   local git = require("neogit.lib.git")
   local group = require("neogit").autocmd_group
+  local config = require("neogit.config")
+
+  if config.values.auto_fetch_enabled and config.values.auto_fetch_on_startup then
+    api.nvim_create_autocmd("VimEnter", {
+      callback = function()
+        if git.cli.is_inside_worktree(".") then
+          local repo = require("neogit.lib.git.repository").instance(".")
+          vim.schedule(function()
+            repo:_fetch()
+          end)
+        end
+      end,
+      group = group,
+    })
+  end
 
   api.nvim_create_autocmd({ "ColorScheme" }, {
     callback = function()

--- a/lua/neogit/lib/git/fetch.lua
+++ b/lua/neogit/lib/git/fetch.lua
@@ -12,32 +12,16 @@ function M.fetch_interactive(remote, branch, args)
   return git.cli.fetch.args(remote or "", branch or "").arg_list(args).call { pty = true }
 end
 
-local a = require("plenary.async")
-local notification = require("neogit.lib.notification")
-
----@param remote string
----@param branch string
+---@param remote string | nil
+---@param branch string | nil
 function M.fetch(remote, branch)
-  notification.info("Fetching...")
-  a.void(function()
-    local result = git.cli.fetch.args(remote, branch).call { ignore_error = true }
+  local result = git.cli.fetch.args(remote, branch).call { ignore_error = true }
 
-    if result and result.code == 0 then
-      notification.info("Fetch complete.")
-    elseif result then
-      local error_message = "Fetch failed: "
-      if type(result.stderr) == "table" then
-        error_message = error_message .. table.concat(result.stderr, "\n")
-      elseif type(result.stderr) == "string" then
-        error_message = error_message .. result.stderr
-      else
-        error_message = error_message .. "Unknown error format."
-      end
-      notification.error(error_message)
-    else
-      notification.error("Fetch failed: An unexpected error occurred and no result was returned.")
-    end
-  end)()
+  if result and result.code == 0 then
+    return true, result
+  else
+    return false, result
+  end
 end
 
 return M


### PR DESCRIPTION
This PR introduces an automatic fetching feature that periodically fetches from all remotes.

### Configuration

The auto-fetch feature is controlled by the following settings:

- **`auto_fetch_enabled`**: A boolean to enable or disable the feature. It is `false` by default.
- **`auto_fetch_interval`**: The time in milliseconds between fetches. Defaults to `300000` (5 minutes).
- **`auto_fetch_on_startup`**: A boolean to perform a fetch immediately when Neogit starts. Defaults to `false`.

When enabled, Neogit will execute `git fetch --all` at the specified interval.

Closes #1670
