### PR TITLE
Show a warning notification when commit fails

### DIFF
--- a/lua/neogit/popups/commit/actions.lua
+++ b/lua/neogit/popups/commit/actions.lua
@@ -37,6 +37,7 @@ local function do_commit(popup, cmd)
     autocmd = "NeogitCommitComplete",
     msg = {
       success = "Committed",
+      fail = "Commit failed",
     },
     interactive = true,
     show_diff = config.values.commit_editor.show_staged_diff,


### PR DESCRIPTION
If a commit isn't successful due to `pre-commit` hook failure, nothing gets reported and the user has to guess what happened.

Ideally, process output should be shown so the user can see what happened. But a notification will at least show that something went wrong.