### PR TITLE
use nvim_buf_add_highlight() (deprecated) for neovim 0.10 and below, …

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -457,7 +457,12 @@ end
 function Buffer:add_highlight(line, col_start, col_end, name, namespace)
   local ns_id = self:get_namespace_id(namespace)
   if ns_id then
-    vim.hl.range(self.handle, ns_id, name, { line, col_start }, { line, col_end })
+    local version = vim.version()
+    if version.major == 0 and version.minor <= 10 then
+      api.nvim_buf_add_highlight(self.handle, ns_id, name, line, col_start, col_end)
+    else
+      vim.hl.range(self.handle, ns_id, name, { line, col_start }, { line, col_end })
+    end
   end
 end
 


### PR DESCRIPTION
Resolves error in add_highlight() when using neovim version 0.10 and lower