### PR TITLE
fix: enable `CloseFold` command in status mappings

### DIFF
--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -639,6 +639,7 @@ function M.get_default_values()
         ["<tab>"] = "Toggle",
         ["za"] = "Toggle",
         ["zo"] = "OpenFold",
+        ["zc"] = "CloseFold",
         ["zC"] = "Depth1",
         ["zO"] = "Depth4",
         ["x"] = "Discard",


### PR DESCRIPTION
This is a quick and small fix to expose the `CloseFold` action in status mappings. This enables config such as: 

```lua
-- ...
mappings = {
  status = {
    [">"] = "OpenFold",
    ["<"] = "CloseFold",
  }
}
-- ...
```