### PR TITLE
fix: disable commit message trimming on `reword`

### DIFF
--- a/lua/neogit/lib/git/log.lua
+++ b/lua/neogit/lib/git/log.lua
@@ -440,7 +440,7 @@ function M.message(commit)
 end
 
 function M.full_message(commit)
-  return git.cli.log.max_count(1).format("%B").args(commit).call({ hidden = true }).stdout
+  return git.cli.log.max_count(1).format("%B").args(commit).call({ hidden = true, trim = false }).stdout
 end
 
 ---@class CommitItem


### PR DESCRIPTION
Currently, when performing `reword` on a commit that has whitespace-separated lines, `Neogit` undesirably trims the message.

This behavior is quite bothering, especially if a user uses `--signoff` option.

For example, a commit with a message:

```Gitcommit
fix: disable commit message trimming on `reword`

Signed-off-by: Andrew Chmutov <achmutov@proton.me>
```

is trimmed to

```git
fix: disable commit message trimming on `reword`
Signed-off-by: Andrew Chmutov <achmutov@proton.me>
```

when `reword`'ing.

The suggested changes preserve the whitespace.