### PR TITLE
Add shortstat to margin popup

### DIFF
--- a/lua/neogit/buffers/status/ui.lua
+++ b/lua/neogit/buffers/status/ui.lua
@@ -5,6 +5,7 @@ local common = require("neogit.buffers.common")
 local config = require("neogit.config")
 local a = require("plenary.async")
 local state = require("neogit.lib.state")
+local git = require("neogit.lib.git")
 
 local col = Ui.col
 local row = Ui.row
@@ -365,73 +366,98 @@ local SectionItemCommit = Component.new(function(item)
 
   -- Render author and date in margin, if visible
   if state.get({ "margin", "visibility" }, false) then
-    local margin_date_style = state.get({ "margin", "date_style" }, 1)
-    local details = state.get({ "margin", "details" }, false)
+    local is_shortstat = state.get({ "margin", "shortstat" }, false)
 
-    local date
-    local rel_date
-    local date_width = 10
-    local clamp_width = 30 -- to avoid having too much space when relative date is short
+    if is_shortstat then
+      local cli_shortstat = git.cli.show.format("").shortstat.args(item.commit.oid).call().stdout[1]
+      local files_changed
+      local insertions
+      local deletions
 
-    -- Render date
-    if item.commit.rel_date:match(" years?,") then
-      rel_date, _ = item.commit.rel_date:gsub(" years?,", "y")
-      rel_date = rel_date .. " "
-    elseif item.commit.rel_date:match("^%d ") then
-      rel_date = " " .. item.commit.rel_date
-    else
-      rel_date = item.commit.rel_date
-    end
+      files_changed = cli_shortstat:match("^ (%d+) files?")
+      files_changed = util.str_min_width(files_changed, 3, nil, false)
+      insertions = cli_shortstat:match("(%d+) insertions?")
+      insertions = util.str_min_width(insertions and insertions .. "+" or " ", 5, nil, false)
+      deletions = cli_shortstat:match("(%d+) deletions?")
+      deletions = util.str_min_width(deletions and deletions .. "-" or " ", 5, nil, false)
 
-    if margin_date_style == 1 then -- relative date (short)
-      local unpacked = vim.split(rel_date, " ")
+      virtual_text = {
+        { " ", "Constant" },
+        { insertions, "NeogitDiffAdditions" },
+        { " ", "Constant" },
+        { deletions, "NeogitDiffDeletions" },
+        { " ", "Constant" },
+        { files_changed, "NeogitSubtleText" },
+      }
+    else -- Author & date margin
+      local margin_date_style = state.get({ "margin", "date_style" }, 1)
+      local details = state.get({ "margin", "details" }, false)
 
-      -- above, we added a space if the rel_date started with a single number
-      -- we get the last two elements to deal with that
-      local date_number = unpacked[#unpacked - 1]
-      local date_quantifier = unpacked[#unpacked]
-      if date_quantifier:match("months?") then
-        date_quantifier = date_quantifier:gsub("m", "M") -- to distinguish from minutes
-      end
+      local date
+      local rel_date
+      local date_width = 10
+      local clamp_width = 30 -- to avoid having too much space when relative date is short
 
-      -- add back the space if we have a single number
-      local left_pad
-      if #unpacked > 2 then
-        left_pad = " "
+      -- Render date
+      if item.commit.rel_date:match(" years?,") then
+        rel_date, _ = item.commit.rel_date:gsub(" years?,", "y")
+        rel_date = rel_date .. " "
+      elseif item.commit.rel_date:match("^%d ") then
+        rel_date = " " .. item.commit.rel_date
       else
-        left_pad = ""
+        rel_date = item.commit.rel_date
       end
 
-      date = left_pad .. date_number .. date_quantifier:sub(1, 1)
-      date_width = 3
-      clamp_width = 23
-    elseif margin_date_style == 2 then -- relative date (long)
-      date = rel_date
-      date_width = 10
-    else -- local iso date
-      if config.values.log_date_format == nil then
-        -- we get the unix date to be able to convert the date to the local timezone
-        date = os.date("%Y-%m-%d %H:%M", item.commit.unix_date)
-        date_width = 16 -- TODO: what should the width be here?
-      else
-        date = item.commit.log_date
-        date_width = 16
-      end
-    end
+      if margin_date_style == 1 then -- relative date (short)
+        local unpacked = vim.split(rel_date, " ")
 
-    local author_table = { "" }
-    if details then
-      author_table = {
-        util.str_clamp(item.commit.author_name, clamp_width - (#date > date_width and #date or date_width)),
-        "NeogitGraphAuthor",
+        -- above, we added a space if the rel_date started with a single number
+        -- we get the last two elements to deal with that
+        local date_number = unpacked[#unpacked - 1]
+        local date_quantifier = unpacked[#unpacked]
+        if date_quantifier:match("months?") then
+          date_quantifier = date_quantifier:gsub("m", "M") -- to distinguish from minutes
+        end
+
+        -- add back the space if we have a single number
+        local left_pad
+        if #unpacked > 2 then
+          left_pad = " "
+        else
+          left_pad = ""
+        end
+
+        date = left_pad .. date_number .. date_quantifier:sub(1, 1)
+        date_width = 3
+        clamp_width = 23
+      elseif margin_date_style == 2 then -- relative date (long)
+        date = rel_date
+        date_width = 10
+      else -- local iso date
+        if config.values.log_date_format == nil then
+          -- we get the unix date to be able to convert the date to the local timezone
+          date = os.date("%Y-%m-%d %H:%M", item.commit.unix_date)
+          date_width = 16 -- TODO: what should the width be here?
+        else
+          date = item.commit.log_date
+          date_width = 16
+        end
+      end
+
+      local author_table = { "" }
+      if details then
+        author_table = {
+          util.str_clamp(item.commit.author_name, clamp_width - (#date > date_width and #date or date_width)),
+          "NeogitGraphAuthor",
+        }
+      end
+
+      virtual_text = {
+        { " ", "Constant" },
+        author_table,
+        { util.str_min_width(date, date_width), "Special" },
       }
     end
-
-    virtual_text = {
-      { " ", "Constant" },
-      author_table,
-      { util.str_min_width(date, date_width), "Special" },
-    }
   end
 
   return row(

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -41,6 +41,7 @@ local runner = require("neogit.runner")
 
 ---@class GitCommandShow: GitCommandBuilder
 ---@field stat self
+---@field shortstat self
 ---@field oneline self
 ---@field no_patch self
 ---@field format fun(string): self
@@ -396,6 +397,7 @@ local configurations = {
   show = config {
     flags = {
       stat = "--stat",
+      shortstat = "--shortstat",
       oneline = "--oneline",
       no_patch = "--no-patch",
     },

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -197,13 +197,21 @@ end
 --   return res
 -- end
 
-function M.str_min_width(str, len, sep)
+---@param append boolean? If true or nil, adds spaces to the end of `str`. If false, adds spaces to the beginning
+function M.str_min_width(str, len, sep, append)
+  append = append == nil and true or append
   local length = vim.fn.strdisplaywidth(str)
   if length > len then
     return str
   end
 
-  return str .. string.rep(sep or " ", len - length)
+  if append then
+    -- Add spaces to the right of str
+    return str .. string.rep(sep or " ", len - length)
+  else
+    -- Add spaces to the left of str
+    return string.rep(sep or " ", len - length) .. str
+  end
 end
 
 function M.slice(tbl, s, e)
@@ -255,8 +263,10 @@ function M.str_truncate(str, max_length, trailing)
   return str
 end
 
-function M.str_clamp(str, len, sep)
-  return M.str_min_width(M.str_truncate(str, len - 1, ""), len, sep or " ")
+---@param append boolean? If true or nil, adds spaces to the end of `str`. If false, adds spaces to the beginning
+function M.str_clamp(str, len, sep, append)
+  append = append == nil and true or append
+  return M.str_min_width(M.str_truncate(str, len - 1, ""), len, sep or " ", append)
 end
 
 --- Splits a string every n characters, respecting word boundaries

--- a/lua/neogit/popups/margin/actions.lua
+++ b/lua/neogit/popups/margin/actions.lua
@@ -29,4 +29,10 @@ function M.toggle_details()
   state.set({ "margin", "details" }, new_details)
 end
 
+function M.toggle_shortstat()
+  local shortstat = state.get({ "margin", "shortstat" }, false)
+  local new_shortstat = not shortstat
+  state.set({ "margin", "shortstat" }, new_shortstat)
+end
+
 return M

--- a/lua/neogit/popups/margin/init.lua
+++ b/lua/neogit/popups/margin/init.lua
@@ -50,7 +50,7 @@ function M.create(env)
     :action("L", "toggle visibility", actions.toggle_visibility, { persist_popup = true })
     :action("l", "cycle style", actions.cycle_date_style, { persist_popup = true })
     :action("d", "toggle details", actions.toggle_details, { persist_popup = true })
-    :action("x", "toggle shortstat", actions.log_current, { persist_popup = true })
+    :action("x", "toggle shortstat", actions.toggle_shortstat, { persist_popup = true })
     :build()
 
   p:show()


### PR DESCRIPTION
This is implemented pretty much as in Magit: by calling `git show --format= --shortstat` for each commit. In the Magit source, this is [described](https://github.com/magit/magit/blob/fd1882b8c981c5e859522bde1dd9c88af9485709/lisp/magit-log.el#L1605) as "experimental and rather slow", but it seems to work just fine for medium-sized repos. Largeish repos (e.g. [rust's](https://github.com/rust-lang/rust)) cause some slowdown in Neogit, but I didn't see a significant difference when testing with vs. without this patch.

In order to (mostly) follow Magit's presentation, I had to add an optional argument to a couple of util functions, so that I could pad strings with spaces to the left (rather than to the right). This should be OK, but I'll flag these changes for review just in case.

One thing to note is that the UI assumes the addition and the deletion columns will take up to 5 characters (4 digits and a +/- sign), and the changed files column up to 3 characters. Magit will still try to display the columns if any of them go over those limits, but the alignment breaks. This is also the case for this implementation, although the alignment breaks in a slightly different way (see the screenshot below). At first this bugged me, but I think this is reasonable. Trying to display the data at the possible cost of breaking alignment seems better than the alternatives (clamping numbers; pre-allocating more space than needed; etc), and certainly better than preemptively optimizing around single commits that add/delete 10,000+ lines over 1,000+ files.

<img width="1880" height="373" alt="shortstat_difference" src="https://github.com/user-attachments/assets/010161e6-b65e-4af1-a0df-ff4b114341a8" />
