### PR TITLE
fix(popups/reset): branch expects commits

### DIFF
--- a/lua/neogit/popups/reset/actions.lua
+++ b/lua/neogit/popups/reset/actions.lua
@@ -98,4 +98,16 @@ function M.a_file(popup)
   end
 end
 
+---@param popup PopupData
+function M.a_branch(popup)
+  -- branch reset expects commits to be set, not commit
+  if popup.state.env.commit then
+    popup.state.env.commits = { popup.state.env.commit }
+    popup.state.env.commit = nil
+  end
+
+  local branch_actions = require("neogit.popups.branch.actions")
+  branch_actions.reset_branch(popup)
+end
+
 return M

--- a/lua/neogit/popups/reset/init.lua
+++ b/lua/neogit/popups/reset/init.lua
@@ -1,6 +1,5 @@
 local popup = require("neogit.lib.popup")
 local actions = require("neogit.popups.reset.actions")
-local branch_actions = require("neogit.popups.branch.actions")
 
 local M = {}
 
@@ -10,7 +9,7 @@ function M.create(env)
     :name("NeogitResetPopup")
     :group_heading("Reset")
     :action("f", "file", actions.a_file)
-    :action("b", "branch", branch_actions.reset_branch)
+    :action("b", "branch", actions.a_branch)
     :new_action_group("Reset this")
     :action("m", "mixed    (HEAD and index)", actions.mixed)
     :action("s", "soft     (HEAD only)", actions.soft)


### PR DESCRIPTION
Reset popup -> branch expects commit under cursor to be in `commits` rather than the in `commit` like the other reset actions.

To reproduce:

1. `:Neogit`
2. place cursor over recent commit
3. open reset popup with `X`
4. select branch option with `b`

expected:
commit under cursor is in picker

actual:
commit is not in picker