### PR TITLE
Use `--force-with-lease` in push popup

### DIFF
--- a/lua/neogit/popups/push/actions.lua
+++ b/lua/neogit/popups/push/actions.lua
@@ -51,9 +51,9 @@ local function push_to(args, remote, branch, opts)
   if res and res:failure() and not using_force and updates_rejected and config.values.prompt_force_push then
     logger.error("Attempting force push to " .. name)
 
-    local message = "Your branch has diverged from the remote branch. Do you want to force push?"
+    local message = "Your branch has diverged from the remote branch. Do you want to force push with lease?"
     if input.get_permission(message) then
-      table.insert(args, "--force")
+      table.insert(args, "--force-with-lease")
       res = git.push.push_interactive(remote, branch, args)
     end
   end


### PR DESCRIPTION
This PR updates the force push logic in the push popup to use `--force-with-lease` instead of `--force` to avoid overwriting someone else's changes by mistake.

Closes #1649