### PR TITLE
Ignore users' configuration `diff.noprefix`

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -1174,6 +1174,7 @@ local function new_builder(subcommand)
         "--no-optional-locks",
         "-c", "core.preloadindex=true",
         "-c", "color.ui=always",
+        "-c", "diff.noprefix=false",
         subcommand
       },
       cmd


### PR DESCRIPTION
Recently when I trying to discard a hunk with neogit, an error raised: `hunk has no filepath`, It turns out somehow I set the `diff.norefix` in my global git configurations, while neogit rely on the prefix `a/` and `b/` for location. so we should alway set `diff.nopreix` to false when building command.