### PR TITLE
Pass through the search prompt if there were no matches when using Snacks picker.

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -185,8 +185,8 @@ local function snacks_confirm(on_select, allow_multi, refocus_status)
     local picker_selected = picker:selected { fallback = true }
 
     if #picker_selected == 0 then
-      complete(nil)
-      picker:close()
+      local prompt = picker:filter().pattern
+      table.insert(selection, prompt)
     elseif #picker_selected > 1 then
       for _, item in ipairs(picker_selected) do
         table.insert(selection, item.text)


### PR DESCRIPTION
This brings the behaviour in line with the Telescope picker: https://github.com/NeogitOrg/neogit/blob/d6112de97160a09c767e2b9dfba45e8942cbd5a4/lua/neogit/lib/finder.lua#L56

I noticed this trying to do a soft reset with HEAD^1 as the argument, as someone else was asking about here: https://github.com/NeogitOrg/neogit/discussions/1669