### PR TITLE
Use parent commit for rebase.subset.

### DIFF
--- a/lua/neogit/lib/git/rebase.lua
+++ b/lua/neogit/lib/git/rebase.lua
@@ -63,6 +63,10 @@ function M.onto_branch(branch, args)
 end
 
 function M.onto(start, newbase, args)
+  if vim.tbl_contains(args, "--root") then
+    start = ""
+  end
+
   local result = rebase_command(git.cli.rebase.onto.args(newbase, start).arg_list(args))
   if result:failure() then
     notification.error("Rebasing failed. Resolve conflicts before continuing")

--- a/lua/neogit/popups/rebase/actions.lua
+++ b/lua/neogit/popups/rebase/actions.lua
@@ -136,10 +136,18 @@ function M.subset(popup)
     )
       :open_async()[1]
   end
-
-  if start then
-    git.rebase.onto(start, newbase, popup:get_arguments())
+  if not start then
+    return
   end
+
+  local args = popup:get_arguments()
+  local parent = git.log.parent(start)
+  if parent then
+    start = start .. "^"
+  else
+    table.insert(args, "--root")
+  end
+  git.rebase.onto(start, newbase, args)
 end
 
 function M.continue()


### PR DESCRIPTION
Similar to the interactive rebase case, the parent of the selected commit needs to be used so that the selected commit is in the range of commits being rebased.

Fixes: https://github.com/NeogitOrg/neogit/issues/1812