### PR TITLE
docs: fix formatting and syntax of git_services

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,27 +100,28 @@ neogit.setup {
   -- Show message with spinning animation when a git command is running.
   process_spinner = false,
   -- Used to generate URL's for branch popup action "pull request", "open commit" and "open tree"
-    git_services = {
-      ["github.com"] = {
-        pull_request = "https://github.com/${owner}/${repository}/compare/${branch_name}?expand=1",
-        commit = "https://github.com/${owner}/${repository}/commit/${oid}",
-        tree = "https://${host}/${owner}/${repository}/tree/${branch_name}",
-      },
-      ["bitbucket.org"] = {
-        pull_request = "https://bitbucket.org/${owner}/${repository}/pull-requests/new?source=${branch_name}&t=1",
-        commit = "https://bitbucket.org/${owner}/${repository}/commits/${oid}",
-        tree = "https://bitbucket.org/${owner}/${repository}/branch/${branch_name}",
-      },
-      ["gitlab.com"] = {
-        pull_request = "https://gitlab.com/${owner}/${repository}/merge_requests/new?merge_request[source_branch]=${branch_name}",
-        commit = "https://gitlab.com/${owner}/${repository}/-/commit/${oid}",
-        tree = "https://gitlab.com/${owner}/${repository}/-/tree/${branch_name}?ref_type=heads",
-      },
-      ["azure.com"] = {
-        pull_request = "https://dev.azure.com/${owner}/_git/${repository}/pullrequestcreate?sourceRef=${branch_name}&targetRef=${target}",
-        commit = "",
-        tree = "",
-      },
+  git_services = {
+    ["github.com"] = {
+      pull_request = "https://github.com/${owner}/${repository}/compare/${branch_name}?expand=1",
+      commit = "https://github.com/${owner}/${repository}/commit/${oid}",
+      tree = "https://${host}/${owner}/${repository}/tree/${branch_name}",
+    },
+    ["bitbucket.org"] = {
+      pull_request = "https://bitbucket.org/${owner}/${repository}/pull-requests/new?source=${branch_name}&t=1",
+      commit = "https://bitbucket.org/${owner}/${repository}/commits/${oid}",
+      tree = "https://bitbucket.org/${owner}/${repository}/branch/${branch_name}",
+    },
+    ["gitlab.com"] = {
+      pull_request = "https://gitlab.com/${owner}/${repository}/merge_requests/new?merge_request[source_branch]=${branch_name}",
+      commit = "https://gitlab.com/${owner}/${repository}/-/commit/${oid}",
+      tree = "https://gitlab.com/${owner}/${repository}/-/tree/${branch_name}?ref_type=heads",
+    },
+    ["azure.com"] = {
+      pull_request = "https://dev.azure.com/${owner}/_git/${repository}/pullrequestcreate?sourceRef=${branch_name}&targetRef=${target}",
+      commit = "",
+      tree = "",
+    },
+  },
   -- Allows a different telescope sorter. Defaults to 'fuzzy_with_index_bias'. The example below will use the native fzf
   -- sorter instead. By default, this function returns `nil`.
   telescope_sorter = function()


### PR DESCRIPTION
Thanks for the Neogit plugin.

The `git_services` section in the README is incorrectly indented and it's missing a closing brace, so here's a fix.