### PR TITLE
fix: fixed auto_close_console not working for pre-commit hooks

### DIFF
--- a/lua/neogit/client.lua
+++ b/lua/neogit/client.lua
@@ -77,6 +77,10 @@ function M.editor(target, client, show_diff)
   logger.debug(("[CLIENT] Invoked editor with target: %s, from: %s"):format(target, client))
   require("neogit.process").hide_preview_buffers()
 
+  if config.values.auto_close_console then
+    require("neogit.process").close_git_hook_buffers()
+  end
+
   local rpc_client = RPC.create_connection(client)
 
   ---on_unload callback when closing editor

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -115,6 +115,20 @@ function Process.hide_preview_buffers()
   end
 end
 
+function Process.close_git_hook_buffers()
+  for _, v in pairs(processes) do
+    if v.git_hook then
+      v:close()
+    end
+  end
+end
+
+function Process:close()
+  if self.buffer then
+    self.buffer:close()
+  end
+end
+
 function Process:show_console()
   if self.buffer then
     self.buffer:show()


### PR DESCRIPTION
Somehow the closing of the "Neogit console" float recently stopped working in the context of running pre-commit hooks, preventing me from seeing the commit buffer (I am using a split for the commit view).

The problem can be easily reproduced by putting something long running with output into the commit-hook that returns fine with exit code 0. And then try to commit.
For Example
```bash
for i in {1..10}; do
    echo "Waiting $i seconds..."
    sleep 1
done
```

I am not really sure as to the root cause of this issue, because i am very sure that this worked at some point, but couldn't find a commit where this worked.

If you have any input or would like me to make changes let me know!