### PR TITLE
Use correct destination branch in pushing another branch

### DIFF
--- a/lua/neogit/popups/push/actions.lua
+++ b/lua/neogit/popups/push/actions.lua
@@ -129,8 +129,8 @@ function M.push_other(popup)
     return
   end
 
-  local remote, _ = git.branch.parse_remote_branch(destination)
-  push_to(popup:get_arguments(), remote, source .. ":" .. destination)
+  local remote, dest_branch = git.branch.parse_remote_branch(destination)
+  push_to(popup:get_arguments(), remote, source .. ":" .. dest_branch)
 end
 
 ---@param prompt string


### PR DESCRIPTION
Fixes a problem that happens when pushing a branch that is not the current branch to the remote by `P` `o` command.
Previously, for example, when pushing a branch named `master` to `origin/master`, a branch called `origin/origin/master` is created on the remote. This PR fixes this.