### PR TITLE
Fix: jump to hunk location from status view not working

### DIFF
--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -62,10 +62,8 @@ local function translate_cursor_location(self, item)
     for _, hunk in ipairs(item.diff.hunks) do
       if line >= hunk.first and line <= hunk.last then
         local offset = line - hunk.first
-        local location = jump.translate_hunk_location(hunk, offset)
-        if location then
-          return { location.new, 0 }
-        end
+        local row = jump.adjust_row(hunk.disk_from, offset, hunk.lines, "-")
+        return { row, 0 }
       end
     end
   end

--- a/lua/neogit/lib/jump.lua
+++ b/lua/neogit/lib/jump.lua
@@ -14,7 +14,7 @@ local M = {}
 ---@param lines string[]
 ---@param adjust_on string
 ---@return integer
-local function adjust_row(start_line, offset, lines, adjust_on)
+function M.adjust_row(start_line, offset, lines, adjust_on)
   local row = start_line + offset - 1
 
   for i = 1, offset do
@@ -39,8 +39,8 @@ function M.translate_hunk_location(hunk, offset)
   end
 
   return {
-    old = adjust_row(hunk.disk_from, offset, hunk.lines, "+"),
-    new = adjust_row(hunk.index_from, offset, hunk.lines, "-"),
+    old = M.adjust_row(hunk.disk_from, offset, hunk.lines, "+"),
+    new = M.adjust_row(hunk.index_from, offset, hunk.lines, "-"),
     line = hunk.lines[offset] or "",
   }
 end


### PR DESCRIPTION
- Fix a bug introduced in PR #1862.
- `hunk.disk_from` was used before that PR to calculate row to jump. After that, hunk.index_from was used. This commit recovers the previous behavior.