### PR TITLE
docs(config): add missing file mode "T" option in README and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ neogit.setup {
       C = "copied",
       U = "updated",
       R = "renamed",
+      T = "changed",
       DD = "unmerged",
       AU = "unmerged",
       UD = "unmerged",

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -214,6 +214,7 @@ to Neovim users.
         C = "copied",
         U = "updated",
         R = "renamed",
+        T = "changed",
         DD = "unmerged",
         AU = "unmerged",
         UD = "unmerged",


### PR DESCRIPTION
This option was available in the source but missing from the configuration documentation.