### PR TITLE
docs: add missing comma in README.md configuration table

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ neogit.setup {
   --   "date"         chronological order by commit date
   --   "author-date"  chronological order by author date
   --   ""             disable explicit ordering (fastest, recommended for very large repos)
-  commit_order = "topo"
+  commit_order = "topo",
   -- Default for new branch name prompts
   initial_branch_name = "",
   -- Change the default way of opening neogit


### PR DESCRIPTION
The sample configuration table in README.md is missing a comma after commit_order = "topo", which causes a Lua syntax error when copied as-is. Added the missing comma.