### PR TITLE
feat: Basic submodule support

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ neogit.setup {
       ["y"] = "ShowRefs",
       ["$"] = "CommandHistory",
       ["Y"] = "YankSelected",
+      ["gp"] = "GoToParentRepo",
       ["<c-r>"] = "RefreshBuffer",
       ["<cr>"] = "GoToFile",
       ["<s-cr>"] = "PeekFile",

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -484,6 +484,7 @@ The following mappings can all be customized via the setup function.
         ["y"]      = "ShowRefs",
         ["$"]      = "CommandHistory",
         ["Y"]      = "YankSelected",
+        ["gp"]      = "GoToParentRepo",
         ["<c-r>"]  = "RefreshBuffer",
         ["<cr>"]   = "GoToFile",
         ["<s-cr>"] = "PeekFile",

--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -1276,6 +1276,18 @@ M.n_unstage_staged = function(self)
   end)
 end
 
+---Opens neogit on the parent repo if if we are in a submodule
+---@param self StatusBuffer
+M.n_goto_parent_repo = function(self)
+  return function()
+    local parent = self:parent_repo()
+    if parent then
+      self:close()
+      require("neogit").open { cwd = parent }
+    end
+  end
+end
+
 ---@param self StatusBuffer
 ---@return fun(): nil
 M.n_goto_file = function(self)
@@ -1284,6 +1296,12 @@ M.n_goto_file = function(self)
 
     -- Goto FILE
     if item and item.absolute_path then
+      if self:has_submodule(item.absolute_path) then
+        self:close()
+        require("neogit").open { cwd = item.absolute_path }
+        return
+      end
+
       local cursor = translate_cursor_location(self, item)
       self:close()
       vim.schedule_wrap(open)("edit", item.absolute_path, cursor)

--- a/lua/neogit/buffers/status/init.lua
+++ b/lua/neogit/buffers/status/init.lua
@@ -22,6 +22,41 @@ M.__index = M
 
 local instances = {}
 
+---@class SubmoduleInfo
+---@field submodules string[] A list with the relative paths to the project's submodules
+---@field parent_repo string? If we are in a submodule, cache the abs path to the parent repo
+
+---@type table<string, SubmoduleInfo>
+local submodule_info_per_root = {}
+
+---@return string?
+function M:parent_repo()
+  local info = submodule_info_per_root[self.root]
+  return info and info.parent_repo
+end
+
+---@return string[]
+function M:submodules()
+  local info = submodule_info_per_root[self.root]
+  return info and info.submodules or {}
+end
+
+---@param abs_path string
+---@return boolean
+function M:has_submodule(abs_path)
+  local dir = require("plenary.path"):new(abs_path)
+  if not dir:exists() or not dir:is_dir() then
+    return false
+  end
+  local rel_path = dir:make_relative(self.cwd)
+  for _, submodule in ipairs(self:submodules()) do
+    if submodule == rel_path then
+      return true
+    end
+  end
+  return false
+end
+
 ---@param instance StatusBuffer
 ---@param dir string
 function M.register(instance, dir)
@@ -29,6 +64,10 @@ function M.register(instance, dir)
   logger.debug("[STATUS] Registering instance for: " .. dir)
 
   instances[dir] = instance
+  submodule_info_per_root[instance.root] = {
+    submodules = git.submodule.list(),
+    parent_repo = git.rev_parse.parent_repo(),
+  }
 end
 
 ---@param dir? string
@@ -170,6 +209,7 @@ function M:open(kind)
         [mappings["Unstage"]]                   = self:_action("n_unstage"),
         [mappings["UnstageStaged"]]             = self:_action("n_unstage_staged"),
         [mappings["GoToFile"]]                  = self:_action("n_goto_file"),
+        [mappings["GoToParentRepo"]]            = self:_action("n_goto_parent_repo"),
         [mappings["TabOpen"]]                   = self:_action("n_tab_open"),
         [mappings["SplitOpen"]]                 = self:_action("n_split_open"),
         [mappings["VSplitOpen"]]                = self:_action("n_vertical_split_open"),

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -222,6 +222,7 @@ end
 ---| "Untrack"
 ---| "RefreshBuffer"
 ---| "GoToFile"
+---| "GoToParentRepo",
 ---| "PeekFile"
 ---| "VSplitOpen"
 ---| "SplitOpen"
@@ -705,6 +706,7 @@ function M.get_default_values()
         ["y"] = "ShowRefs",
         ["$"] = "CommandHistory",
         ["Y"] = "YankSelected",
+        ["gp"] = "GoToParentRepo",
         ["<c-r>"] = "RefreshBuffer",
         ["<cr>"] = "GoToFile",
         ["<s-cr>"] = "PeekFile",

--- a/lua/neogit/lib/git.lua
+++ b/lua/neogit/lib/git.lua
@@ -25,6 +25,7 @@
 ---@field sequencer   NeogitGitSequencer
 ---@field stash       NeogitGitStash
 ---@field status      NeogitGitStatus
+---@field submodule   NeogitGitSubmodule
 ---@field tag         NeogitGitTag
 ---@field worktree    NeogitGitWorktree
 ---@field hooks       NeogitGitHooks

--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -84,6 +84,8 @@ end
 ---@field null_separated self
 ---@field porcelain fun(string): self
 
+---@class GitCommandSubmodule: GitCommandBuilder
+
 ---@class GitCommandLog: GitCommandBuilder
 ---@field oneline self
 ---@field branches self
@@ -321,6 +323,7 @@ end
 ---@field no_flags self
 ---@field symbolic self
 ---@field symbolic_full_name self
+---@field show_superproject_working_tree self
 ---@field abbrev_ref fun(ref: string): self
 
 ---@class GitCommandCherryPick: GitCommandBuilder
@@ -374,6 +377,7 @@ end
 ---@field show-ref       GitCommandShowRef
 ---@field stash          GitCommandStash
 ---@field status         GitCommandStatus
+---@field submodule      GitCommandSubmodule
 ---@field tag            GitCommandTag
 ---@field update-index   GitCommandUpdateIndex
 ---@field update-ref     GitCommandUpdateRef
@@ -467,6 +471,8 @@ local configurations = {
       porcelain = "--porcelain",
     },
   },
+
+  submodule = config {},
 
   log = config {
     flags = {
@@ -971,6 +977,7 @@ local configurations = {
       no_flags = "--no-flags",
       symbolic = "--symbolic",
       symbolic_full_name = "--symbolic-full-name",
+      show_superproject_working_tree = "--show-superproject-working-tree",
     },
     options = {
       abbrev_ref = "--abbrev-ref",

--- a/lua/neogit/lib/git/rev_parse.lua
+++ b/lua/neogit/lib/git/rev_parse.lua
@@ -39,4 +39,9 @@ function M.full_name(rev)
     .call({ hidden = true, ignore_error = true }).stdout[1]
 end
 
+---@return string?
+function M.parent_repo()
+  return git.cli["rev-parse"].show_superproject_working_tree.call({ hidden = true, ignore_error = true }).stdout[1]
+end
+
 return M

--- a/lua/neogit/lib/git/submodule.lua
+++ b/lua/neogit/lib/git/submodule.lua
@@ -1,0 +1,14 @@
+local git = require("neogit.lib.git")
+
+---@class NeogitGitSubmodule
+local M = {}
+
+---@return string[]
+function M.list()
+  local result = git.cli.submodule.call({ hidden = true, ignore_error = true }).stdout
+  return vim.tbl_map(function(el)
+    return vim.split(vim.trim(el), " +", { trimempty = true })[2]
+  end, result)
+end
+
+return M


### PR DESCRIPTION
This PR aims to provide some support to work with submodules. It's motivated by the issue #1822 

New functionality:
- When hitting `<cr>` on a submodule entry with changes in the status view, a new neogit instance is opened with the submodule as root.
- When inside the status view of a submodule, hitting `gp` (default for the new `GoToParentRepo` mapping) opens a new neogit instance with the parent repo as root.

Implementation details:
- On new neogit instance creation, information about submodules and parent repo is cached.
- Helper functions are defined to get the submodule under the cursor or the parent repo if present.
- New git commands were added to:
    - Get a list of the submodules in the repo (in the new `git/submodule.lua` file)
    - Get the path to the parent repo (as a new flag for the `rev_parse` command)
- The feature was validated manually but a new integration test was also introduced.