### PR TITLE
Fix: autosquash command (`r f`) bug is fixed.

### DIFF
--- a/lua/neogit/popups/rebase/actions.lua
+++ b/lua/neogit/popups/rebase/actions.lua
@@ -164,19 +164,22 @@ function M.edit()
 end
 
 function M.autosquash(popup)
+  local args = util.deduplicate(util.merge(popup:get_arguments(), { "--autosquash", "--keep-empty" }))
   local base
   if popup.state.env.commit and git.log.is_ancestor(popup.state.env.commit, "HEAD") then
-    base = popup.state.env.commit
+    local parent = git.log.parent(popup.state.env.commit)
+    if parent then
+      base = popup.state.env.commit .. "^"
+    else
+      base = popup.state.env.commit
+      table.insert(args, "--root")
+    end
   else
     base = git.rebase.merge_base_HEAD()
   end
 
   if base then
-    git.rebase.onto(
-      "HEAD",
-      base,
-      util.deduplicate(util.merge(popup:get_arguments(), { "--autosquash", "--keep-empty" }))
-    )
+    git.rebase.rebase_interactive(base, args)
   end
 end
 


### PR DESCRIPTION
When `r f` is pressed, obtain the parent of currently specified commit as new base and run a interactive (autosquashing) rebase onto the commit.
Currently, there's a bug that deletes the rebased commits (#1620). This PR fixes it.