### PR TITLE
feat: allow to customize initial name on branch rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ neogit.setup {
   commit_order = "topo",
   -- Default for new branch name prompts
   initial_branch_name = "",
+  -- Default for rename branch prompt. If not set, the current branch name is used
+  initial_branch_rename = nil,
   -- Change the default way of opening neogit
   kind = "tab",
   -- Floating window style 

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -179,6 +179,8 @@ to Neovim users.
     commit_order = "topo"
     -- Default for new branch name prompts
     initial_branch_name = "",
+    -- Default for rename branch prompt. If not set, the current branch name is used
+    initial_branch_rename = nil,
     -- Change the default way of opening neogit
     kind = "tab",
     -- Floating window style

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -366,6 +366,7 @@ end
 ---@field sort_branches? string Value used for `--sort` for the `git branch` command
 ---@field commit_order? NeogitCommitOrder Value used for `--<commit_order>-order` for the `git log` command
 ---@field initial_branch_name? string Default for new branch name prompts
+---@field initial_branch_rename? string Default for rename branch prompt. If not set, the current branch name is used
 ---@field kind? WindowKind The default type of window neogit should open in
 ---@field floating? NeogitConfigFloating The floating window style
 ---@field disable_line_numbers? boolean Whether to disable line numbers
@@ -1200,6 +1201,7 @@ function M.validate_config()
     validate_type(config.remember_settings, "remember_settings", "boolean")
     validate_type(config.sort_branches, "sort_branches", "string")
     validate_type(config.initial_branch_name, "initial_branch_name", "string")
+    validate_type(config.initial_branch_rename, "initial_branch_name", { "string", "nil" })
     validate_type(config.notification_icon, "notification_icon", "string")
     validate_type(config.console_timeout, "console_timeout", "number")
     validate_kind(config.kind, "kind")

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -240,7 +240,8 @@ function M.rename_branch()
     return
   end
 
-  local new_name = get_branch_name_user_input(("Rename '%s' to"):format(selected_branch))
+  local default_branch_name = config.values.initial_branch_rename or selected_branch
+  local new_name = get_branch_name_user_input(("Rename '%s' to"):format(selected_branch), default_branch_name)
   if not new_name then
     return
   end

--- a/tests/specs/neogit/config_spec.lua
+++ b/tests/specs/neogit/config_spec.lua
@@ -61,6 +61,11 @@ describe("Neogit config", function()
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
       end)
 
+      it("should return invalid when initial_branch_rename isn't an optional string", function()
+        config.values.initial_branch_rename = false
+        assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
+      end)
+
       it("should return invalid when kind isn't a string", function()
         config.values.kind = true
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
@@ -563,6 +568,16 @@ describe("Neogit config", function()
 
       it("should return valid when a command mappings.finder is a boolean", function()
         config.values.mappings.finder["c"] = false
+        assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
+      end)
+
+      it("should return valid when initial_branch_rename is string", function()
+        config.values.initial_branch_rename = "default-name"
+        assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
+      end)
+
+      it("should return valid when initial_branch_rename is nil", function()
+        config.values.initial_branch_rename = nil
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) == 0)
       end)
     end)


### PR DESCRIPTION
Currently, when renaming a branch, the input is prefilled with `initial_branch_name`, introduced in #1517.

However, at some point in time, Neogit used the current branch name. This feature was introduced in #904, but was lost over the time.

This PR introduces `initial_branch_rename` config feature. By default, the value is `nil`, which indicates current branch name. Otherwise, i.e. if string is provided, the value behaves like `initial_branch_name`.

Attaching a demo with:
* `initial_branch_name` set to `initial_branch_name`
* `initial_branch_rename` set to `nil` (default)

https://github.com/user-attachments/assets/758d9bd2-10db-42a4-8002-591e462c96bc

