### PR TITLE
feat: add prompt_amend_commit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ neogit.setup {
   git_executable = "git",
   -- Offer to force push when branches diverge
   prompt_force_push = true,
+  -- Request confirmation when amending already published commits
+  prompt_amend_commit = true,
   -- Changes what mode the Commit Editor starts in. `true` will leave nvim in normal mode, `false` will change nvim to
   -- insert mode, and `"auto"` will change nvim to insert mode IF the commit message is empty, otherwise leaving it in
   -- normal mode.

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -98,6 +98,8 @@ to Neovim users.
     git_executable = "git",
     -- Offer to force push when branches diverge
     prompt_force_push = true,
+    -- Request confirmation when amending already published commits
+    prompt_amend_commit = true,
     -- Changes what mode the Commit Editor starts in. `true` will leave nvim in normal mode, `false` will change nvim to
     -- insert mode, and `"auto"` will change nvim to insert mode IF the commit message is empty, otherwise leaving it in
     -- normal mode.

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -356,6 +356,7 @@ end
 ---@field disable_context_highlighting? boolean Disable context highlights based on cursor position
 ---@field disable_signs? boolean Special signs to draw for sections etc. in Neogit
 ---@field prompt_force_push? boolean Offer to force push when branches diverge
+---@field prompt_amend_commit? boolean Request confirmation when amending already published commits
 ---@field git_services? NeogitConfigGitService[] Templates to use when opening a pull request for a branch, or commit
 ---@field fetch_after_checkout? boolean Perform a fetch if the newly checked out branch has an upstream or pushRemote set
 ---@field telescope_sorter? function The sorter telescope will use
@@ -406,6 +407,7 @@ function M.get_default_values()
     disable_context_highlighting = false,
     disable_signs = false,
     prompt_force_push = true,
+    prompt_amend_commit = true,
     graph_style = "ascii",
     commit_date_format = nil,
     log_date_format = nil,

--- a/lua/neogit/popups/commit/actions.lua
+++ b/lua/neogit/popups/commit/actions.lua
@@ -19,6 +19,7 @@ local function confirm_modifications()
   if
     git.branch.upstream()
     and #git.repo.state.upstream.unmerged.items < 1
+    and config.values.prompt_amend_commit
     and not input.get_permission(
       string.format(
         "This commit has already been published to %s, do you really want to modify it?",


### PR DESCRIPTION
This adds an option to disable the confirmation prompt when amending a commit that has already been pushed. This can be useful for users that regularly amend commits while working on a branch by themselves.