### PR TITLE
fix: prevent `--literal-pathspecs` leaking into git hooks

### DIFF
--- a/lua/neogit/lib/git/cli.lua
+++ b/lua/neogit/lib/git/cli.lua
@@ -1205,6 +1205,7 @@ local function new_builder(subcommand)
       table.insert(cmd, "-")
     end
 
+    -- stylua: ignore
     local base = {
       get_git_executable(),
       "--no-pager",


### PR DESCRIPTION
Neogit currently adds `--literal-pathspecs` to all git commands, which causes git to export `GIT_LITERAL_PATHSPECS=1` to hooks. Hook managers such as [hk](https://hk.jdx.dev/) can fail when running `git stash`.

e.g. git error:

```
pathspec ':/' did not match any file(s) known to git
```

in this case commits abort with `Commit failed` before the message editor opens.

This change skips `--literal-pathspecs` for hook-triggering subcommands (commit/merge/rebase/checkout/push), preventing the env leak while keeping the flag for other commands.
