### PR TITLE
fix(buffer): guard ViewContext line_hl against neogit_disable_hunk_highlight

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -871,17 +871,21 @@ function Buffer.create(config)
         local cursor = fn.line(".")
         local start = math.max(context.position.row_start, fn.line("w0"))
         local stop = math.min(context.position.row_end, fn.line("w$"))
+        local disable_hl = vim.b.neogit_disable_hunk_highlight == true
 
         for line = start, stop do
-          local line_hl = ("%s%s"):format(
-            buffer.ui:get_line_highlight(line) or "NeogitDiffContext",
-            line == cursor and "Cursor" or "Highlight"
-          )
+          local is_cursor = line == cursor
+          if is_cursor or not disable_hl then
+            local line_hl = ("%s%s"):format(
+              buffer.ui:get_line_highlight(line) or "NeogitDiffContext",
+              is_cursor and "Cursor" or "Highlight"
+            )
 
-          buffer:add_line_highlight(line - 1, line_hl, {
-            priority = 200,
-            namespace = "ViewContext",
-          })
+            buffer:add_line_highlight(line - 1, line_hl, {
+              priority = 200,
+              namespace = "ViewContext",
+            })
+          end
         end
       end,
     })


### PR DESCRIPTION
## Problem

When `neogit_disable_hunk_highlight = true` is set on a buffer (introduced
in #1897 for third-party plugin interop), the `HunkLine` renderer correctly
skips its own highlights — but the `ViewContext` decoration provider's
`on_win` callback was still applying `NeogitDiffContextHighlight` as
`line_hl_group` on every visible line in the cursor's section. Because
`line_hl_group` operates on a separate stacking layer, it overrides
third-party backgrounds (e.g. `DiffsAdd`/`DiffsDelete` from diffs.nvim)
regardless of extmark priority, making them invisible.

## Solution

Check `neogit_disable_hunk_highlight` per-line inside the ViewContext loop.
When set, skip `add_line_highlight` for non-cursor lines. The cursor-line
indicator (`NeogitDiffContextCursorHighlight`) is preserved.