### PR TITLE
Add "pre-event" hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,13 @@ This works for just about everything that has an object-ID in git, and if you fi
 
 See the built-in documentation for a comprehensive list of highlight groups. If your theme doesn't style a particular group, we'll try our best to do a nice job.
 
+## Hooks
+
+Neogit supports hooks for the following actions:
+
+| Hook                | Description                    | Hook Data                 |
+| ------------------- | ------------------------------ | ------------------------- |
+| `PreBranchCheckout` | Before a branch is checked out | `{ branch_name: string }` |
 
 ## Events
 

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -324,6 +324,9 @@ end
 ---| "author-date"
 ---| "date"
 
+---@alias NeogitHook
+---| "PreBranchCheckout"
+
 ---@class NeogitConfigStatusOptions
 ---@field recent_commit_count? integer The number of recent commits to display
 ---@field mode_padding? integer The amount of padding to add to the right of the mode column
@@ -402,6 +405,7 @@ end
 ---@field treesitter_diff_highlight? boolean Apply syntax highlighting to diff hunks via treesitter
 ---@field word_diff_highlight? boolean Apply word-diff highlighting to diff hunks
 ---@field builders? { [string]: fun(builder: PopupBuilder) }
+---@field hooks? { [NeogitHook]: fun(data: table?) }
 
 ---Returns the default Neogit configuration
 ---@return NeogitConfig
@@ -420,6 +424,7 @@ function M.get_default_values()
     log_date_format = nil,
     log_pager = nil,
     process_spinner = false,
+    hooks = {},
     filewatcher = {
       enabled = true,
     },

--- a/lua/neogit/lib/hook.lua
+++ b/lua/neogit/lib/hook.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+local config = require("neogit.config")
+
+---@param name NeogitHook
+---@param data table?
+function M.run(name, data)
+  assert(name, "hook must have name")
+
+  if config.values.hooks[name] then
+    config.values.hooks[name](data)
+  end
+end
+
+return M

--- a/lua/neogit/popups/branch/actions.lua
+++ b/lua/neogit/popups/branch/actions.lua
@@ -6,6 +6,7 @@ local input = require("neogit.lib.input")
 local util = require("neogit.lib.util")
 local notification = require("neogit.lib.notification")
 local event = require("neogit.lib.event")
+local hook = require("neogit.lib.hook")
 local a = require("neogit.lib.async")
 
 local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
@@ -21,6 +22,8 @@ local function fetch_remote_branch(target)
 end
 
 local function checkout_branch(target, args)
+  hook.run("PreBranchCheckout", { branch_name = target })
+
   local result = git.branch.checkout(target, args)
   if result:failure() then
     notification.error(table.concat(result.stderr, "\n"))
@@ -73,6 +76,7 @@ local function spin_off_branch(checkout)
   local current_branch_name = git.branch.current_full_name()
 
   if checkout then
+    hook.run("PreBranchCheckout", { branch_name = name })
     git.cli.checkout.branch(name).call()
     event.send("BranchCheckout", { branch_name = name })
   end
@@ -188,6 +192,8 @@ function M.checkout_local_branch(popup)
   }
 
   if target then
+    hook.run("PreBranchCheckout", { branch_name = target })
+
     if vim.tbl_contains(remote_branches, target) then
       local result = git.branch.track(target, popup:get_arguments())
       if result:failure() then


### PR DESCRIPTION
This is a POC for hooks as requested in #1909. This PR will remain a draft during the iteration and planning phase. Once an approach is agreed upon, then this PR will be cleaned up to be a candidate for merging.

I am not fluent in lua, so please be critical with coding standards.

**Testing done:**
I've run this locally on my own config to solve the problem from the aforementioned issue. I added the following to my neogit config:

```lua
    hooks = {
      ["PreBranchCheckout"] = function()
        local neogit = require("neogit")
        local autosession = require("auto-session")

        neogit.close()
        autosession.SaveSession(nil, false)
        neogit.open()
      end,
    },
```

The function body can be replaced with `print("Running PreBranchCheckout")` for a simple verification.

**Neovim versions tested on:**
- [ ] 0.13 (nightly)
- [x] 0.12
- [x] 0.11
- [ ] 0.10
- [ ] 0.9

**OSes tests on:**
- [x] arch linux
- [x] macos
- [ ] windows

**Remaining work:**
- [x] add more hooks, ideally one-to-one for all events
    - [x] `PreStatusRefreshed`
    - [x] `PreCommitComplete`
    - [x] `PrePushComplete`
    - [x] `PrePullComplete`
    - [x] `PreFetchComplete`
    - [x] `PreBranchCreate`
    - [x] `PreBranchDelete`
    - [x] `PreBranchCheckoustate:open t`
    - [x] `PreBranchReset`
    - [x] `PreBranchRename`
    - [x] `PreRebase`
    - [x] `PreReset`
    - [x] `PreTagCreate`
    - [x] `PreTagDelete`
    - [x] `PreCherryPick`
    - [x] `PreMerge`
    - [x] `PreStash`
    - [x] `RefsRefreshed`
    - [x] `DiffLoaded`
    - [x] `Bisect`
    - [x] `WorktreeCreate`
- [x] update documentation
- [ ] update tests