### PR TITLE
use `diffview.nvim` public API instead of internal modules

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -128,7 +128,7 @@ body:
         M.setup({
           plenary = "https://github.com/nvim-lua/plenary.nvim.git",
           telescope = "https://github.com/nvim-telescope/telescope.nvim",
-          diffview = "https://github.com/sindrets/diffview.nvim",
+          diffview = "https://github.com/dlyongemallo/diffview.nvim",
           neogit = "https://github.com/NeogitOrg/neogit"
         })
         -- WARN: Do all plugin setup, test runs, reproductions, etc. AFTER calling setup with a list of plugins!

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           git config --global core.compression 0
           git clone https://github.com/nvim-lua/plenary.nvim tmp/plenary
           git clone https://github.com/nvim-telescope/telescope.nvim tmp/telescope
-          git clone https://github.com/sindrets/diffview.nvim tmp/diffview
+          git clone https://github.com/dlyongemallo/diffview.nvim tmp/diffview
           git clone https://github.com/nvim-telescope/telescope-fzf-native.nvim tmp/telescope-fzf-native
           cd tmp/telescope-fzf-native
           make

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           git config --global core.compression 0
           git clone https://github.com/nvim-lua/plenary.nvim tmp/plenary
           git clone https://github.com/nvim-telescope/telescope.nvim tmp/telescope
-          git clone https://github.com/dlyongemallo/diffview.nvim tmp/diffview
+          git clone --branch v0.30 --depth 1 https://github.com/dlyongemallo/diffview.nvim tmp/diffview
           git clone https://github.com/nvim-telescope/telescope-fzf-native.nvim tmp/telescope-fzf-native
           cd tmp/telescope-fzf-native
           make

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ neogit.setup {
     -- Neogit only provides inline diffs. If you want a more traditional way to look at diffs, you can use `diffview`.
     -- The diffview integration enables the diff popup.
     --
-    -- Requires you to have `dlyongemallo/diffview.nvim` installed.
+    -- Requires you to have `dlyongemallo/diffview.nvim` v0.30+ installed.
     diffview = nil,
 
     -- Alternative diff viewer integration.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Here's an example spec for [Lazy](https://github.com/folke/lazy.nvim), but you'r
     "nvim-lua/plenary.nvim",         -- required
 
     -- Only one of these is needed.
-    "sindrets/diffview.nvim",        -- optional
+    "dlyongemallo/diffview.nvim",        -- optional
     "esmuellert/codediff.nvim",      -- optional
 
     -- For a custom log pager
@@ -332,7 +332,7 @@ neogit.setup {
     -- Neogit only provides inline diffs. If you want a more traditional way to look at diffs, you can use `diffview`.
     -- The diffview integration enables the diff popup.
     --
-    -- Requires you to have `sindrets/diffview.nvim` installed.
+    -- Requires you to have `dlyongemallo/diffview.nvim` installed.
     diffview = nil,
 
     -- Alternative diff viewer integration.

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -289,7 +289,7 @@ to Neovim users.
         -- Neogit only provides inline diffs. If you want a more traditional way to look at diffs, you can use `diffview`.
         -- The diffview integration enables the diff popup.
         --
-        -- Requires you to have `sindrets/diffview.nvim` installed.
+        -- Requires you to have `dlyongemallo/diffview.nvim` installed.
         diffview = nil,
 
         -- Alternative diff viewer integration.
@@ -1462,7 +1462,7 @@ ref range.
 
 For these actions to become available, Neogit needs to have a diff viewer
 integration enabled. Supported viewers are:
-- `diffview.nvim`: https://github.com/sindrets/diffview.nvim
+- `diffview.nvim`: https://github.com/dlyongemallo/diffview.nvim
 - `codediff.nvim`: https://github.com/esmuellert/codediff.nvim
 
 By default, Neogit will auto-detect which viewer is available. You can

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -289,7 +289,7 @@ to Neovim users.
         -- Neogit only provides inline diffs. If you want a more traditional way to look at diffs, you can use `diffview`.
         -- The diffview integration enables the diff popup.
         --
-        -- Requires you to have `dlyongemallo/diffview.nvim` installed.
+        -- Requires you to have `dlyongemallo/diffview.nvim` v0.30+ installed.
         diffview = nil,
 
         -- Alternative diff viewer integration.

--- a/lua/neogit/integrations/diffview.lua
+++ b/lua/neogit/integrations/diffview.lua
@@ -1,16 +1,32 @@
 local M = {}
 
-local Rev = require("diffview.vcs.adapters.git.rev").GitRev
-local RevType = require("diffview.vcs.rev").RevType
-local CDiffView = require("diffview.api.views.diff.diff_view").CDiffView
-local dv_lib = require("diffview.lib")
-local dv_utils = require("diffview.utils")
+local dv_ok, dv_api = pcall(require, "diffview.api.views.diff.diff_view")
+local CDiffView = dv_ok and dv_api.CDiffView or nil
+local Rev = dv_ok and dv_api.Rev or nil
+local RevType = dv_ok and dv_api.RevType or nil
 
 local Watcher = require("neogit.watcher")
 local git = require("neogit.lib.git")
-local a = require("plenary.async")
+
+if dv_ok then
+  vim.api.nvim_create_autocmd("User", {
+    group = vim.api.nvim_create_augroup("NeogitDiffviewIntegration", { clear = true }),
+    pattern = "DiffviewFilesStaged",
+    callback = function()
+      local watcher = Watcher.instance()
+      if not vim.tbl_isempty(watcher.buffers) then
+        watcher:dispatch_refresh()
+      end
+    end,
+  })
+end
 
 local function get_local_diff_view(section_name, item_name, opts)
+  if not CDiffView then
+    vim.notify("Neogit: diffview.nvim v0.30+ is required for this feature.", vim.log.levels.WARN)
+    return nil
+  end
+
   local left = Rev(RevType.STAGE)
   local right = Rev(RevType.LOCAL)
 
@@ -92,13 +108,6 @@ local function get_local_diff_view(section_name, item_name, opts)
     end,
   }
 
-  view:on_files_staged(a.void(function(_)
-    Watcher.instance():dispatch_refresh()
-    view:update_files()
-  end))
-
-  dv_lib.add_view(view)
-
   return view
 end
 
@@ -117,7 +126,16 @@ function M.open(section_name, item_name, opts)
     })
   end
 
-  local view
+  local dv_open = function(args)
+    local ok, diffview = pcall(require, "diffview")
+    if not ok or type(diffview.open) ~= "function" or not dv_ok then
+      vim.notify("Neogit: diffview.nvim v0.30+ is required for this feature.", vim.log.levels.WARN)
+      return
+    end
+
+    diffview.open(args or {})
+  end
+
   -- selene: allow(if_same_then_else)
   if
     (section_name == "recent" or section_name == "log" or (section_name and section_name:match("unmerged$")))
@@ -130,26 +148,25 @@ function M.open(section_name, item_name, opts)
       range = string.format("%s^!", item_name:match("[a-f0-9]+"))
     end
 
-    view = dv_lib.diffview_open(dv_utils.tbl_pack(range))
+    dv_open({ range })
   elseif section_name == "range" and item_name then
-    view = dv_lib.diffview_open(dv_utils.tbl_pack(item_name))
+    dv_open({ item_name })
   elseif (section_name == "stashes" or section_name == "commit") and item_name then
-    view = dv_lib.diffview_open(dv_utils.tbl_pack(item_name .. "^!"))
+    dv_open({ item_name .. "^!" })
   elseif section_name == "conflict" and item_name then
-    view = dv_lib.diffview_open(dv_utils.tbl_pack("--selected-file=" .. item_name))
+    dv_open({ "--selected-file=" .. item_name })
   elseif (section_name == "conflict" or section_name == "worktree") and not item_name then
-    view = dv_lib.diffview_open()
+    dv_open()
   elseif section_name ~= nil then
-    -- for staged, unstaged, merge
-    view = get_local_diff_view(section_name, item_name, opts)
+    -- For staged, unstaged, merge: use CDiffView directly.
+    local view = get_local_diff_view(section_name, item_name, opts)
+    if view then
+      view:open()
+    end
   elseif section_name == nil and item_name ~= nil then
-    view = dv_lib.diffview_open(dv_utils.tbl_pack(item_name .. "^!"))
+    dv_open({ item_name .. "^!" })
   else
-    view = dv_lib.diffview_open()
-  end
-
-  if view then
-    view:open()
+    dv_open()
   end
 end
 

--- a/spec/support/dependencies.rb
+++ b/spec/support/dependencies.rb
@@ -4,7 +4,7 @@ def dir_name(name)
   name.match(%r{[^/]+/(?<dir_name>[^\.]+)})[:dir_name]
 end
 
-def ensure_installed(name, build: nil)
+def ensure_installed(name, build: nil, branch: nil)
   tmp = File.join(PROJECT_DIR, "tmp")
   FileUtils.mkdir_p(tmp)
 
@@ -14,7 +14,9 @@ def ensure_installed(name, build: nil)
 
   puts "Downloading dependency #{name} to #{dir}"
   Dir.mkdir(dir)
-  Git.clone("git@github.com:#{name}.git", dir, filter: "tree:0")
+  opts = { filter: "tree:0" }
+  opts[:branch] = branch if branch
+  Git.clone("git@github.com:#{name}.git", dir, **opts)
   return unless build.present?
 
   puts "Building #{name} via #{build}"
@@ -24,4 +26,4 @@ end
 ensure_installed "nvim-lua/plenary.nvim"
 ensure_installed "nvim-telescope/telescope.nvim"
 ensure_installed "nvim-telescope/telescope-fzf-native.nvim", build: "make"
-ensure_installed "dlyongemallo/diffview.nvim"
+ensure_installed "dlyongemallo/diffview.nvim", branch: "v0.30"

--- a/spec/support/dependencies.rb
+++ b/spec/support/dependencies.rb
@@ -24,4 +24,4 @@ end
 ensure_installed "nvim-lua/plenary.nvim"
 ensure_installed "nvim-telescope/telescope.nvim"
 ensure_installed "nvim-telescope/telescope-fzf-native.nvim", build: "make"
-ensure_installed "sindrets/diffview.nvim"
+ensure_installed "dlyongemallo/diffview.nvim"


### PR DESCRIPTION
Neogit currently accesses `diffview.nvim` internal implementation details, which leads to bugs when the code changes, such as happened in https://github.com/dlyongemallo/diffview.nvim/issues/93. 

This changes fixes the problem by using `diffview.nvim` through the public API. Requires [v0.30](https://github.com/dlyongemallo/diffview.nvim/releases/tag/v0.30) or higher of the maintained fork of `diffview.nvim` (so PR #1939 is a pre-requisite).