### PR TITLE
Set default red color based on ErrorMsg

### DIFF
--- a/lua/neogit/lib/hl.lua
+++ b/lua/neogit/lib/hl.lua
@@ -91,7 +91,7 @@ end
 local function make_palette(config)
   local bg        = Color.from_hex(get_bg("Normal") or (vim.o.bg == "dark" and "#22252A" or "#eeeeee"))
   local fg        = Color.from_hex((vim.o.bg == "dark" and "#fcfcfc" or "#22252A"))
-  local red       = Color.from_hex(config.highlight.red or get_fg("Error") or "#E06C75")
+  local red       = Color.from_hex(config.highlight.red or get_fg("ErrorMsg") or "#E06C75")
   local orange    = Color.from_hex(config.highlight.orange or get_fg("SpecialChar") or "#ffcb6b")
   local yellow    = Color.from_hex(config.highlight.yellow or get_fg("PreProc") or "#FFE082")
   local green     = Color.from_hex(config.highlight.green or get_fg("String") or "#C3E88D")


### PR DESCRIPTION
The previously used Error highlight group does not actually have a red foreground in the default Neovim color scheme. It has a red background and white foreground. The ErrorMsg group is probably more likely to have a red foreground in most color schemes.