### PR TITLE
fix: console buffer reuse after terminal open

### DIFF
--- a/lua/neogit/lib/buffer.lua
+++ b/lua/neogit/lib/buffer.lua
@@ -725,6 +725,12 @@ function Buffer.create(config)
 
   local buffer = Buffer.from_name(config.name)
 
+  local existing_buftype = buffer:get_option("buftype")
+  if existing_buftype == "terminal" and config.buftype ~= "terminal" then
+    api.nvim_buf_delete(buffer.handle, { force = true })
+    buffer = Buffer.from_name(config.name)
+  end
+
   buffer.name = config.name
   buffer.kind = config.kind or "split"
 


### PR DESCRIPTION
## Summary
- Prevent Neogit from reusing a `NeogitConsole` buffer after `nvim_open_term()` has turned it into a terminal buffer.
- Recreate stale terminal-backed console buffers before applying non-terminal buffer options.

## Problem
- Reopening the console could hit `E474: Invalid argument` when Neogit tried to set `buftype = "nofile"` on a buffer that was already `buftype = "terminal"`.
- My environment:
```
NVIM v0.12.1
Build type: Release
LuaJIT 2.1.1774638290
Run "nvim -V1 -v" for more info

Debian 13.3 on WSL
```

## Fix
- Add a guard in `Buffer.create()` that detects terminal-backed reused buffers.
- Delete and recreate the buffer before applying the standard Neogit buffer options.

## Verification
- Ran `make test`
- All tests passed
