### PR TITLE
fix: use item.name instead of escaped_path in merge conflict check

### DIFF
--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -1146,7 +1146,7 @@ M.n_stage = function(self)
 
       if selection.item and selection.item.mode == "UU" then
         local diff_viewer = config.get_diff_viewer()
-        if diff_viewer and git.merge.is_conflicted(selection.item.escaped_path) then
+        if diff_viewer and git.merge.is_conflicted(selection.item.name) then
           local integration = diff_viewer == "codediff" and require("neogit.integrations.codediff")
             or require("neogit.integrations.diffview")
           integration.open("conflict", selection.item.name, {


### PR DESCRIPTION
escaped_path is fnamemodify(absolute_path, ":~:."), which is relative to Vim's CWD. Git commands run with worktree_root as CWD. When neogit is opened with cwd=%:p:h pointing to a subdirectory, is_conflicted() receives a path relative to the wrong directory, git diff --check finds nothing, exits 0, and diffview never opens — showing the staging notification instead.

Use item.name (from git status output, already relative to git root) consistent with every other is_conflicted call in this function.

Fixes d93d7813