### PR TITLE
Add opt-in `stream_hook_output` to show git hook output live (e.g. post-checkout migrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ neogit.setup {
   auto_show_console = true,
   -- Automatically close the console if the process exits with a 0 (success) status
   auto_close_console = true,
+  -- Stream git-hook output (e.g. post-checkout) to the console live as it runs.
+  -- Closes on success, stays open on failure. Off by default. (Excludes rebase/bisect.)
+  stream_hook_output = false,
   notification_icon = "󰊢",
   status = {
     show_head_commit_hash = true,

--- a/doc/neogit.txt
+++ b/doc/neogit.txt
@@ -206,6 +206,9 @@ to Neovim users.
     auto_show_console = true,
     -- Automatically close the console if the process exits with a 0 (success) status
     auto_close_console = true,
+    -- Stream git-hook output (e.g. post-checkout) to the console live as it runs.
+    -- Closes on success, stays open on failure. Off by default. (Excludes rebase/bisect.)
+    stream_hook_output = false,
     notification_icon = "󰊢",
     status = {
         show_head_commit_hash = true,

--- a/lua/neogit/config.lua
+++ b/lua/neogit/config.lua
@@ -378,6 +378,7 @@ end
 ---@field auto_show_console? boolean Automatically show the console if a command takes longer than console_timeout
 ---@field auto_show_console_on? string Specify "output" (show always; default) or "error" if `auto_show_console` enabled
 ---@field auto_close_console? boolean Automatically hide the console if the process exits with a 0 status
+---@field stream_hook_output? boolean Stream git-hook output (e.g. post-checkout) to the console live while it runs
 ---@field status? NeogitConfigStatusOptions Status buffer options
 ---@field commit_editor? NeogitCommitEditorConfigPopup Commit editor options
 ---@field commit_select_view? NeogitConfigPopup Commit select view options
@@ -480,6 +481,10 @@ function M.get_default_values()
     -- the console always, or "error" to auto-show the console only on error
     auto_show_console_on = "output",
     auto_close_console = true,
+    -- Stream git-hook output (e.g. post-checkout) to the console live while it runs.
+    -- Closes on success, stays open on failure. Off by default. Excludes rebase/bisect
+    -- (their console is suppressed).
+    stream_hook_output = false,
     notification_icon = "󰊢",
     status = {
       show_head_commit_hash = true,
@@ -1250,6 +1255,7 @@ function M.validate_config()
     validate_type(config.auto_show_console, "auto_show_console", "boolean")
     validate_type(config.auto_show_console_on, "auto_show_console_on", "string")
     validate_type(config.auto_close_console, "auto_close_console", "boolean")
+    validate_type(config.stream_hook_output, "stream_hook_output", "boolean")
     if validate_type(config.status, "status", "table") then
       validate_type(config.status.show_head_commit_hash, "status.show_head_commit_hash", "boolean")
       validate_type(config.status.recent_commit_count, "status.recent_commit_count", "number")

--- a/lua/neogit/lib/git/branch.lua
+++ b/lua/neogit/lib/git/branch.lua
@@ -81,18 +81,26 @@ function M.list_containing_branches(commit, ...)
   return M.list_related_branches("--contains", commit, ...)
 end
 
+--- Whether a checkout must block. When `stream_hook_output` is enabled and a
+--- `post-checkout` hook exists, run async (non-blocking) so the hook console can
+--- stream live; otherwise keep the original blocking behavior.
+---@return boolean
+local function checkout_await()
+  return not (config.values.stream_hook_output and git.hooks.exists("checkout"))
+end
+
 ---@param name string
 ---@param args? string[]
 ---@return ProcessResult
 function M.checkout(name, args)
-  return git.cli.checkout.branch(name).arg_list(args or {}).call { await = true }
+  return git.cli.checkout.branch(name).arg_list(args or {}).call { await = checkout_await() }
 end
 
 ---@param name string
 ---@param args? string[]
 ---@return ProcessResult
 function M.track(name, args)
-  return git.cli.checkout.track(name).arg_list(args or {}).call { await = true }
+  return git.cli.checkout.track(name).arg_list(args or {}).call { await = checkout_await() }
 end
 
 ---@param include_current? boolean

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -188,7 +188,9 @@ function Process:start_timer()
           return
         end
 
-        if not config.values.auto_show_console then
+        if self.git_hook and config.values.stream_hook_output then
+          self:show_console()
+        elseif not config.values.auto_show_console then
           local message = string.format(
             "Command %q running for more than: %.1f seconds",
             mask_command(table.concat(self.cmd, " ")),

--- a/tests/specs/neogit/config_spec.lua
+++ b/tests/specs/neogit/config_spec.lua
@@ -96,6 +96,11 @@ describe("Neogit config", function()
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
       end)
 
+      it("should return invalid when stream_hook_output isn't a boolean", function()
+        config.values.stream_hook_output = "not a boolean"
+        assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)
+      end)
+
       it("should return invalid when status isn't a table", function()
         config.values.status = "not a table"
         assert.True(vim.tbl_count(require("neogit.config").validate_config()) ~= 0)

--- a/tests/specs/neogit/lib/git/branch_checkout_await_spec.lua
+++ b/tests/specs/neogit/lib/git/branch_checkout_await_spec.lua
@@ -1,0 +1,60 @@
+local stub = require("luassert.stub")
+local git = require("neogit.lib.git")
+local runner = require("neogit.runner")
+local config = require("neogit.config")
+local branch = require("neogit.lib.git.branch")
+
+describe("branch checkout await", function()
+  local captured
+  local hook_exists
+
+  before_each(function()
+    config.values = config.get_default_values()
+    captured = nil
+    hook_exists = false
+
+    -- Capture the options passed to the runner instead of executing git.
+    stub(runner, "call", function(_, opts)
+      captured = opts
+      return { stdout = {}, stderr = {}, output = {}, code = 0 }
+    end)
+
+    -- Control whether a post-checkout hook is reported as present.
+    stub(git.hooks, "exists", function()
+      return hook_exists
+    end)
+  end)
+
+  after_each(function()
+    runner.call:revert()
+    git.hooks.exists:revert()
+  end)
+
+  it("runs async (await=false) when stream_hook_output is on and a post-checkout hook exists", function()
+    config.values.stream_hook_output = true
+    hook_exists = true
+    branch.checkout("foo")
+    assert.is_false(captured.await)
+  end)
+
+  it("blocks (await=true) when stream_hook_output is on but no post-checkout hook exists", function()
+    config.values.stream_hook_output = true
+    hook_exists = false
+    branch.checkout("foo")
+    assert.is_true(captured.await)
+  end)
+
+  it("blocks (await=true) when stream_hook_output is off even if a hook exists", function()
+    config.values.stream_hook_output = false
+    hook_exists = true
+    branch.checkout("foo")
+    assert.is_true(captured.await)
+  end)
+
+  it("applies the same logic to track()", function()
+    config.values.stream_hook_output = true
+    hook_exists = true
+    branch.track("origin/foo")
+    assert.is_false(captured.await)
+  end)
+end)


### PR DESCRIPTION
## What's this?

A small, **opt-in** config flag — `stream_hook_output` (default `false`) — that lets you actually *watch* a git hook's output stream into the Neogit console while it runs.

My setup runs a `post-checkout` hook (the `hookup` Ruby gem) that runs DB migrations whenever I switch branches. Today that hook fires on every checkout but basically gets lost currently. The output is captured, but it gets swallowed silently. 

## Why it doesn't already work

Turns out checkout is the **only** hook-bearing op that runs *blocking* (`branch.checkout` → `.call { await = true }`). A blocking `jobwait` freezes redraws, and the `vim.schedule`'d "show console" timer can't fire mid-run — by the time it could, the result is already set and it bails, then auto-close finishes it off on success. So the console never gets a chance to stream. Meanwhile `merge`/`push` run async and *already* stream their hook output via the existing 800ms timer — checkout was just the odd one out.

## What the flag does

When `stream_hook_output = true`:

- `branch.checkout`/`track` run **async instead of blocking** — but only when a `post-checkout` hook actually exists — so the existing console machinery can stream the output live as it's produced.
- A tiny tweak in `process.lua`'s timer force-shows the console for hook processes, so it works even if you've turned `auto_show_console` off.
- **Close-on-success / stay-open-on-failure are unchanged** — those already do exactly the right thing (`auto_close_console` + the existing hook-failure branch). So you watch it run, it tidies up after itself on success, and it sticks around so you can read the error if the hook fails.

Default is `false`, so this is **zero behavior change** unless you opt in.

## Scope / notes

- Applies to the non-suppressed hook ops (checkout, merge, push). `rebase`/`bisect` run with `long = true` (console suppressed), so they're intentionally out of scope.
- Switching checkout to async is safe: popup actions already run inside an `a.void` coroutine, so the async path yields and resumes with the `ProcessResult` exactly like before, and the runner falls back to blocking if it's ever called outside a coroutine.

## Tests

- New `branch_checkout_await_spec.lua` asserting checkout takes the async path only when the flag + a `post-checkout` hook are present (and blocks otherwise).
- New config-validation case in `config_spec.lua`.
- Full suite green, `stylua` clean. Documented in README + `doc/neogit.txt`.
