### PR TITLE
fix: handle utf8 relative date abbreviations

### DIFF
--- a/lua/neogit/buffers/reflog_view/ui.lua
+++ b/lua/neogit/buffers/reflog_view/ui.lua
@@ -29,7 +29,7 @@ M.Entry = Component.new(function(entry, total)
   local date
   if config.values.log_date_format == nil then
     local date_number, date_quantifier = unpack(vim.split(entry.rel_date, " "))
-    date = date_number .. date_quantifier:sub(1, 1)
+    date = date_number .. util.str_first_char(date_quantifier)
   else
     date = entry.commit_date
   end

--- a/lua/neogit/buffers/status/ui.lua
+++ b/lua/neogit/buffers/status/ui.lua
@@ -461,7 +461,7 @@ local SectionItemCommit = Component.new(function(item)
           left_pad = ""
         end
 
-        date = left_pad .. date_number .. date_quantifier:sub(1, 1)
+        date = left_pad .. date_number .. util.str_first_char(date_quantifier)
         date_width = 3
         clamp_width = 23
       elseif margin_date_style == 2 then -- relative date (long)

--- a/lua/neogit/lib/util.lua
+++ b/lua/neogit/lib/util.lua
@@ -259,6 +259,10 @@ end
 --   return vim.split(str, "\r?\n")
 -- end
 
+function M.str_first_char(str)
+  return vim.fn.strcharpart(str, 0, 1)
+end
+
 function M.str_truncate(str, max_length, trailing)
   trailing = trailing or "..."
   if vim.fn.strdisplaywidth(str) > max_length then

--- a/tests/specs/neogit/lib/util_spec.lua
+++ b/tests/specs/neogit/lib/util_spec.lua
@@ -1,0 +1,13 @@
+local subject = require("neogit.lib.util")
+
+describe("lib.util", function()
+  describe("#str_first_char", function()
+    it("returns the first ASCII character", function()
+      assert.are.same("s", subject.str_first_char("seconds"))
+    end)
+
+    it("returns the first UTF-8 character", function()
+      assert.are.same("秒", subject.str_first_char("秒前"))
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- add a UTF-8 safe helper for taking the first display character
- use it for status and reflog relative date abbreviations
- add coverage for ASCII and UTF-8 strings

## Tests
- TEST_FILES=tests/specs/neogit/lib/util_spec.lua nvim --headless -u NONE --clean +'set rtp+=.' +'set rtp+=/home/jin/.local/share/nvim/lazy/plenary.nvim' -S tests/init.lua
- nvim --headless -u NONE --clean +'set rtp+=.' +'set rtp+=/home/jin/.local/share/nvim/lazy/plenary.nvim' +'lua require("neogit.lib.util"); require("neogit.buffers.status.ui"); require("neogit.buffers.reflog_view.ui")' +qa