### PR TITLE
fix: discarding new directories

### DIFF
--- a/lua/neogit/buffers/status/actions.lua
+++ b/lua/neogit/buffers/status/actions.lua
@@ -15,14 +15,50 @@ local FuzzyFinderBuffer = require("neogit.buffers.fuzzy_finder")
 local fn = vim.fn
 local api = vim.api
 
+local function absolute_path(path)
+  if vim.startswith(path, "/") then
+    return vim.fs.normalize(path)
+  end
+
+  return vim.fs.normalize(git.repo.worktree_root .. "/" .. path)
+end
+
+local function path_contains(parent, child)
+  parent = vim.fs.normalize(parent)
+  child = vim.fs.normalize(child)
+
+  return child == parent or vim.startswith(child .. "/", parent .. "/")
+end
+
+local function move_cwds_out_of_dir(dir)
+  local root = vim.fs.normalize(git.repo.worktree_root)
+
+  if path_contains(dir, vim.uv.cwd()) then
+    api.nvim_set_current_dir(root)
+  end
+
+  for _, tabpage in ipairs(api.nvim_list_tabpages()) do
+    for _, win in ipairs(api.nvim_tabpage_list_wins(tabpage)) do
+      api.nvim_win_call(win, function()
+        if path_contains(dir, fn.getcwd()) then
+          vim.cmd.lcd(fn.fnameescape(root))
+        end
+      end)
+    end
+  end
+end
+
 local function cleanup_dir(dir)
   if vim.in_fast_event() then
     a.util.scheduler()
   end
 
+  dir = absolute_path(dir)
+  move_cwds_out_of_dir(dir)
+
   for name, type in vim.fs.dir(dir, { depth = math.huge }) do
     if type == "file" then
-      local bufnr = fn.bufnr(name)
+      local bufnr = fn.bufnr(vim.fs.joinpath(dir, name))
       if bufnr > 0 then
         api.nvim_buf_delete(bufnr, { force = false })
       end
@@ -30,6 +66,31 @@ local function cleanup_dir(dir)
   end
 
   fn.delete(dir, "rf")
+end
+
+local function empty_dir(dir)
+  local ok, iter = pcall(vim.fs.dir, dir)
+  return ok and iter and iter() == nil
+end
+
+local function cleanup_empty_parent_dirs(path)
+  local root = vim.fs.normalize(git.repo.worktree_root)
+  local dir = vim.fs.dirname(absolute_path(path))
+
+  while dir and dir ~= "." do
+    dir = vim.fs.normalize(dir)
+
+    if dir == root or not path_contains(root, dir) then
+      break
+    end
+
+    if fn.isdirectory(dir) == 0 or not empty_dir(dir) then
+      break
+    end
+
+    fn.delete(dir, "d")
+    dir = vim.fs.dirname(dir)
+  end
 end
 
 ---@param items StatusItem[]
@@ -42,13 +103,19 @@ local function cleanup_items(items)
     local path = item.absolute_path or item.name
     logger.debug("[cleanup_items()] Cleaning " .. vim.inspect(path))
     assert(path, "cleanup_items() - item must have a name")
+    local resolved_path = absolute_path(path)
 
-    local bufnr = fn.bufnr(path)
+    local bufnr = fn.bufnr(resolved_path)
     if bufnr > 0 then
       pcall(api.nvim_buf_delete, bufnr, { force = false })
     end
 
-    fn.delete(fn.fnameescape(path))
+    if fn.isdirectory(resolved_path) == 1 then
+      cleanup_dir(resolved_path)
+      cleanup_empty_parent_dirs(resolved_path)
+    elseif fn.delete(resolved_path) == 0 then
+      cleanup_empty_parent_dirs(resolved_path)
+    end
   end
 end
 

--- a/spec/buffers/status_buffer_spec.rb
+++ b/spec/buffers/status_buffer_spec.rb
@@ -199,6 +199,21 @@ RSpec.describe "Status Buffer", :git, :nvim do
       end
     end
 
+    context "with untracked directory" do
+      before do
+        FileUtils.mkdir_p("new_dir")
+        File.write("new_dir/new_file.txt", "brand new\n")
+        nvim.refresh
+      end
+
+      it "deletes the directory when discarding the section" do
+        nvim.move_to_line("Untracked files")
+        nvim.confirm(true)
+        nvim.keys("x")
+        await { expect(Dir.exist?("new_dir")).to be false }
+      end
+    end
+
     context "when staged new file" do
       before do
         File.write("new_file.txt", "brand new\n")
@@ -213,6 +228,26 @@ RSpec.describe "Status Buffer", :git, :nvim do
         await do
           expect(`git diff --cached --name-only`.strip).to be_empty
           expect(File.exist?("new_file.txt")).to be false
+        end
+      end
+    end
+
+    context "when staged new file in a new directory" do
+      before do
+        FileUtils.mkdir_p("new_dir")
+        File.write("new_dir/new_file.txt", "brand new\n")
+        git.add("new_dir/new_file.txt")
+        nvim.refresh
+      end
+
+      it "removes it from the index and deletes the empty directory" do
+        nvim.move_to_line("new file   new_dir/new_file.txt", after: "Staged changes")
+        nvim.confirm(true)
+        nvim.keys("x")
+        await do
+          expect(`git diff --cached --name-only`.strip).to be_empty
+          expect(File.exist?("new_dir/new_file.txt")).to be false
+          expect(Dir.exist?("new_dir")).to be false
         end
       end
     end


### PR DESCRIPTION
When executing `x` (Discard) in `Untracked files`

For example, a directory structure like

```
.
├── a
│   └── b
│       └── c
│           └── d
└── e
```

<img width="538" height="207" alt="image" src="https://github.com/user-attachments/assets/eb6c50d6-e6e5-4ca5-a303-2349cf5cc4a7" />


Expected: All untracked files and directories will be recursively discarded
Current Behaviour: Only `e` (files) will be discarded

<img width="538" height="207" alt="image" src="https://github.com/user-attachments/assets/60286794-a4be-40d7-9f0a-48ce74475c96" />

This PR:

* Recursively delete untracked directory items passed through discard cleanup
* Remove empty parent directories after discarding newly-added files
* Move Neovim cwd/window-local cwd out of directories before recursively deleting them
  * Note: This prevents losing focus to the neogit buffer.