### PR TITLE
fix(index): use item.name in checkout_unstaged instead of escaped_path

### DIFF
--- a/lua/neogit/lib/git/index.lua
+++ b/lua/neogit/lib/git/index.lua
@@ -125,7 +125,7 @@ end
 
 function M.checkout_unstaged()
   local items = util.map(git.repo.state.unstaged.items, function(item)
-    return item.escaped_path
+    return item.name
   end)
 
   return git.cli.checkout.files(unpack(items)).call { await = true }


### PR DESCRIPTION
escaped_path produces incorrect paths for git checkout, causing discard of the entire unstaged section to silently do nothing. 