### PR TITLE
fix(input): resume async vim.ui.input await when the prompt closes without a callback

### DIFF
--- a/lua/neogit/lib/async.lua
+++ b/lua/neogit/lib/async.lua
@@ -33,6 +33,22 @@ local function in_async_context()
   return co ~= nil and our_threads[co] == true
 end
 
+--- Sentinel used to resume a suspended await with an *error* rather than a
+--- value.  When a wrapped leaf fn throws synchronously before ever invoking its
+--- callback, `step` resumes the coroutine with `(ASYNC_THROW, err)` so the await
+--- site re-raises instead of parking forever.
+local ASYNC_THROW = {}
+
+--- Unwraps the values a suspended await was resumed with.  If the first value is
+--- the `ASYNC_THROW` sentinel, re-raises the accompanying error inside the
+--- coroutine; otherwise forwards the resume values unchanged (arity-preserving).
+local function resume_or_throw(first, ...)
+  if first == ASYNC_THROW then
+    error((...), 0)
+  end
+  return first, ...
+end
+
 ---@class NeogitTask
 ---@field _done boolean
 ---@field _cancelled boolean
@@ -204,7 +220,23 @@ local function execute(task, async_fn, callback, ...)
     -- The wrapped fn may return a function that cancels the operation it
     -- just kicked off (e.g. killing a process).  Stash it on the task so
     -- cancel() can invoke it.
-    local cancel_handle = fn(unpack(user_args, 1, argc))
+    --
+    -- Guard the call: if the leaf throws synchronously before ever invoking its
+    -- callback (e.g. a process that fails to spawn, a picker that errors on
+    -- open), the coroutine is still suspended at its await.  Resume it with the
+    -- error so the await site re-raises -- letting a surrounding pcall run its
+    -- cleanup (e.g. releasing the popup action lock) -- instead of parking
+    -- forever and wedging that lock for the rest of the session.
+    local ok_fn, cancel_handle = pcall(fn, unpack(user_args, 1, argc))
+    if not ok_fn then
+      if coroutine.status(thread) == "suspended" then
+        return step(ASYNC_THROW, cancel_handle)
+      end
+      if not task._done then
+        finish(false, { cancel_handle, debug.traceback(thread, tostring(cancel_handle)) }, 2)
+      end
+      return
+    end
     if type(cancel_handle) == "function" and not task._done then
       task._current_child = cancel_handle
     end
@@ -249,7 +281,7 @@ function M.wrap(fn, argc)
         2
       )
     end
-    return coroutine.yield(fn, argc, ...)
+    return resume_or_throw(coroutine.yield(fn, argc, ...))
   end
 end
 

--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -340,6 +340,25 @@ end
 ---Engages finder and invokes `on_select` with the item or items, or nil if aborted
 ---@param on_select fun(item: any|nil)
 function Finder:find(on_select)
+  -- `find` is the leaf of an awaited async call (`find_async`), so `on_select`
+  -- is the coroutine's resume. Each picker branch below is a separate place the
+  -- "always call back, even on abort" contract can break; a dropped resume
+  -- parks the awaiting coroutine forever and -- because popup actions hold a
+  -- shared permit lock while awaiting a finder -- silently turns every later
+  -- popup action into a no-op until Neovim restarts. Guarantee the resume fires
+  -- exactly once (here), and give each branch a close/abort net (below).
+  do
+    local resume = on_select
+    local resolved = false
+    on_select = function(item)
+      if resolved then
+        return
+      end
+      resolved = true
+      resume(item)
+    end
+  end
+
   if config.check_integration("telescope") then
     local pickers = require("telescope.pickers")
     local finders = require("telescope.finders")
@@ -359,13 +378,29 @@ function Finder:find(on_select)
       default_sorter = sorters.get_generic_fuzzy_sorter()
     end
 
-    pickers
-      .new(self.opts, {
-        finder = finders.new_table { results = self.entries },
-        sorter = config.values.telescope_sorter() or default_sorter,
-        attach_mappings = telescope_mappings(on_select, self.opts.allow_multi, self.opts.refocus_status),
+    local picker = pickers.new(self.opts, {
+      finder = finders.new_table { results = self.entries },
+      sorter = config.values.telescope_sorter() or default_sorter,
+      attach_mappings = telescope_mappings(on_select, self.opts.allow_multi, self.opts.refocus_status),
+    })
+    picker:find()
+
+    -- Net: telescope resumes only through its mapped Select/Close actions; if the
+    -- prompt buffer is wiped another way (`:q`, a force-close), resume as abort.
+    -- Deferred so a mapped action (which wipes the prompt buffer, then calls
+    -- on_select) wins the once-guard race.
+    local prompt_bufnr = picker.prompt_bufnr
+    if prompt_bufnr and vim.api.nvim_buf_is_valid(prompt_bufnr) then
+      vim.api.nvim_create_autocmd("BufWipeout", {
+        buffer = prompt_bufnr,
+        once = true,
+        callback = function()
+          vim.schedule(function()
+            on_select(nil)
+          end)
+        end,
       })
-      :find()
+    end
   elseif config.check_integration("fzf_lua") then
     local fzf_lua = require("fzf-lua")
     fzf_lua.fzf_exec(self.entries, {
@@ -375,6 +410,16 @@ function Finder:find(on_select)
         height = self.opts.layout_config.height,
         border = self.opts.border,
         preview = { border = self.opts.border },
+        -- Net: fzf-lua skips its exit action (and thus our on_select) when the
+        -- picker closes without a selection (`:q`, a force-close, a killed
+        -- process -- see fzf-lua core "if not exit_code ... return"). on_close
+        -- fires on every window close; deferred so a real selection, dispatched
+        -- right after the window closes, wins the once-guard race.
+        on_close = function()
+          vim.schedule(function()
+            on_select(nil)
+          end)
+        end,
       },
       actions = fzf_actions(on_select, self.opts.allow_multi, self.opts.refocus_status),
     })
@@ -428,6 +473,23 @@ function Finder:find(on_select)
         end
       end)
     end)
+
+    -- Net: some vim.ui.select replacements drop their callback when the prompt
+    -- is dismissed without a selection. If a floating prompt window was entered,
+    -- treat its close without a result as an abort. Deferred so a real callback
+    -- wins the once-guard race.
+    local win = vim.api.nvim_get_current_win()
+    if vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_config(win).relative ~= "" then
+      vim.api.nvim_create_autocmd("WinClosed", {
+        pattern = tostring(win),
+        once = true,
+        callback = function()
+          vim.schedule(function()
+            on_select(nil)
+          end)
+        end,
+      })
+    end
   end
 end
 

--- a/lua/neogit/lib/input.lua
+++ b/lua/neogit/lib/input.lua
@@ -1,5 +1,48 @@
 local a = require("neogit.lib.async")
-local input = a.wrap(vim.ui.input, 2)
+
+-- `vim.ui.input`, hardened against implementations that close their prompt
+-- without ever invoking the callback.
+--
+-- The built-in cmdline input always calls back, but several floating-window
+-- replacements (e.g. snacks.nvim) only call `on_confirm` via their own
+-- confirm/cancel actions and skip it entirely when the window is dismissed
+-- some other way (`:q`, `<C-w>c`, a focus steal, a programmatic close). A
+-- dropped callback parks the awaiting coroutine forever -- and because popup
+-- actions run under a single shared permit lock, one parked action silently
+-- turns *every* subsequent popup action into a no-op until Neovim restarts.
+--
+-- We guarantee the callback fires exactly once: the real value if the user
+-- responds, or `nil` (a normal cancel) if the prompt window closes first.
+local input = a.wrap(function(opts, callback)
+  local done = false
+  local function finish(value)
+    if done then
+      return
+    end
+    done = true
+    callback(value)
+  end
+
+  vim.ui.input(opts, finish)
+
+  -- If the implementation synchronously entered a floating prompt window,
+  -- treat that window closing without a result as a cancel. Deferred so a
+  -- real callback dispatched during the same close wins the race: both the
+  -- value and this fallback get scheduled, and implementations call
+  -- `on_confirm` before closing, so the real value is enqueued first.
+  local win = vim.api.nvim_get_current_win()
+  if not done and vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_config(win).relative ~= "" then
+    vim.api.nvim_create_autocmd("WinClosed", {
+      pattern = tostring(win),
+      once = true,
+      callback = function()
+        vim.schedule(function()
+          finish(nil)
+        end)
+      end,
+    })
+  end
+end, 2)
 
 local M = {}
 

--- a/lua/neogit/process.lua
+++ b/lua/neogit/process.lua
@@ -365,58 +365,74 @@ function Process:spawn(cb)
     -- Remove self
     processes[self.job] = nil
     self.result = res
-    self:stop_timer()
-    self:hide_spinner()
 
-    stdout_cleanup()
-    stderr_cleanup()
+    -- Everything below is best-effort presentation/cleanup (timers, spinner,
+    -- error display, console show/close).  It MUST NOT prevent the resume
+    -- callback from firing: if it threw, the awaiting coroutine would never
+    -- resume, orphaning it -- and because popup actions hold a shared permit
+    -- lock while awaiting a process, that silently wedges every subsequent
+    -- popup action until Neovim restarts.  Guard it so `cb(res)` always runs.
+    local handler_ok, handler_err = pcall(function()
+      self:stop_timer()
+      self:hide_spinner()
 
-    if self.buffer and not self.suppress_console then
-      self.buffer:append(string.format("Process exited with code: %d", code))
-    end
+      stdout_cleanup()
+      stderr_cleanup()
 
-    -- Handle git hook failures and other errors.  Skip entirely if the
-    -- process was killed via Process:stop() (i.e. the surrounding async task
-    -- was cancelled): the non-zero exit is intentional, not a real failure.
-    if code > 0 and not self.killed then
-      local should_show_error = self.on_error(res)
-      local is_hook_failure = self.git_hook and code > 0 and not git.status.any_unmerged()
+      if self.buffer and not self.suppress_console then
+        self.buffer:append(string.format("Process exited with code: %d", code))
+      end
 
-      -- For git hook failures, always show the Git Console
-      if is_hook_failure then
-        -- Simply show the existing buffer with the git hook output
-        if self.buffer then
-          self.buffer:show()
+      -- Handle git hook failures and other errors.  Skip entirely if the
+      -- process was killed via Process:stop() (i.e. the surrounding async task
+      -- was cancelled): the non-zero exit is intentional, not a real failure.
+      if code > 0 and not self.killed then
+        local should_show_error = self.on_error(res)
+        local is_hook_failure = self.git_hook and code > 0 and not git.status.any_unmerged()
+
+        -- For git hook failures, always show the Git Console
+        if is_hook_failure then
+          -- Simply show the existing buffer with the git hook output
+          if self.buffer then
+            self.buffer:show()
+          end
+        end
+
+        -- Handle normal error display logic
+        if should_show_error and not is_hook_failure then
+          local output = {}
+          local start = math.max(#res.stderr - 16, 1)
+          for i = start, math.min(#res.stderr, start + 16) do
+            insert(output, "> " .. util.remove_ansi_escape_codes(res.stderr[i]))
+          end
+
+          if not config.values.auto_close_console then
+            local message = string.format(
+              "%s:\n\n%s",
+              mask_command(table.concat(self.cmd, " ")),
+              table.concat(output, "\n")
+            )
+            notification.warn(message)
+          elseif config.values.auto_show_console_on == "error" and self.buffer then
+            self.buffer:show()
+          end
         end
       end
 
-      -- Handle normal error display logic
-      if should_show_error and not is_hook_failure then
-        local output = {}
-        local start = math.max(#res.stderr - 16, 1)
-        for i = start, math.min(#res.stderr, start + 16) do
-          insert(output, "> " .. util.remove_ansi_escape_codes(res.stderr[i]))
-        end
-
-        if not config.values.auto_close_console then
-          local message =
-            string.format("%s:\n\n%s", mask_command(table.concat(self.cmd, " ")), table.concat(output, "\n"))
-          notification.warn(message)
-        elseif config.values.auto_show_console_on == "error" and self.buffer then
-          self.buffer:show()
-        end
+      -- Close console on success if configured
+      if
+        self.buffer
+        and not self.user_command
+        and config.values.auto_close_console
+        and self.buffer:is_visible()
+        and code == 0
+      then
+        self.buffer:close()
       end
-    end
+    end)
 
-    -- Close console on success if configured
-    if
-      self.buffer
-      and not self.user_command
-      and config.values.auto_close_console
-      and self.buffer:is_visible()
-      and code == 0
-    then
-      self.buffer:close()
+    if not handler_ok then
+      logger.error("[PROCESS] on_exit handler failed: " .. tostring(handler_err))
     end
 
     self.stdin = nil
@@ -440,7 +456,11 @@ function Process:spawn(cb)
   })
 
   if job <= 0 then
-    error("Failed to start process: " .. vim.inspect(self))
+    -- Spawn failed.  Per the spawn_async contract this resolves to nil -- but we
+    -- must actually invoke the callback: `error()` here would abort before the
+    -- (previously dead) cb call, leaving the awaiting coroutine parked forever
+    -- and wedging the shared popup action lock.
+    logger.error("[PROCESS] Failed to start process: " .. vim.inspect(self.cmd))
     if cb then
       cb(nil)
     end

--- a/tests/specs/neogit/lib/async_spec.lua
+++ b/tests/specs/neogit/lib/async_spec.lua
@@ -69,6 +69,67 @@ describe("lib.async", function()
     end)
   end)
 
+  describe("wrap (synchronous leaf failure)", function()
+    -- Regression: a wrapped leaf that throws synchronously before ever invoking
+    -- its callback (e.g. a process that fails to spawn, a picker that errors on
+    -- open) used to leave the coroutine suspended at its await forever. Because
+    -- popup actions hold a shared permit lock while awaiting, one such throw
+    -- wedged the lock and silently turned every later popup action into a no-op.
+    it("re-raises at the await site instead of parking the coroutine", function()
+      local throwing_leaf = async.wrap(function(_cb)
+        error("spawn-boom")
+      end, 1)
+
+      local outcome
+      async.run(function()
+        local ok, err = pcall(throwing_leaf)
+        outcome = { ok = ok, err = err }
+      end)
+
+      wait_for(function()
+        return outcome ~= nil
+      end, 1000)
+
+      assert.is_truthy(outcome) -- did not hang
+      assert.is_false(outcome.ok)
+      assert.is_truthy(tostring(outcome.err):match("spawn%-boom"))
+    end)
+
+    it("releases a held Semaphore permit when the awaited op throws", function()
+      -- Mirrors the popup action pattern: acquire the shared permit, run an
+      -- action that awaits a leaf which throws, release the permit. The parked
+      -- coroutine used to skip forget(), wedging the lock; the next acquirer
+      -- must still get the permit.
+      local sem = async.control.Semaphore.new(1)
+      local throwing_leaf = async.wrap(function(_cb)
+        error("action-boom")
+      end, 1)
+
+      local second_ran = false
+      async.void(function()
+        async.util.run_all({
+          function()
+            local permit = sem:acquire()
+            pcall(throwing_leaf) -- parked-then-orphaned under the old bug
+            permit:forget()
+          end,
+          function()
+            sleep(30) -- let the throwing action acquire first
+            local permit = sem:acquire()
+            second_ran = true
+            permit:forget()
+          end,
+        }, function() end)
+      end)()
+
+      wait_for(function()
+        return second_ran
+      end, 1000)
+
+      assert.is_true(second_ran) -- permit was released; lock is not wedged
+    end)
+  end)
+
   describe("util.run_all", function()
     it("invokes the callback after every async fn completes", function()
       local log = {}

--- a/tests/specs/neogit/lib/finder_spec.lua
+++ b/tests/specs/neogit/lib/finder_spec.lua
@@ -1,0 +1,112 @@
+local Finder = require("neogit.lib.finder")
+local async = require("neogit.lib.async")
+local config = require("neogit.config")
+
+--- Drives the event loop until `predicate()` returns true (or `timeout` ms elapse).
+local function wait_for(predicate, timeout)
+  return vim.wait(timeout or 1000, predicate, 5)
+end
+
+--- Open and enter a floating window, mimicking a `vim.ui.select` replacement
+--- (e.g. snacks.nvim) that synchronously enters its prompt window.
+local function open_float()
+  local buf = vim.api.nvim_create_buf(false, true)
+  return vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    row = 1,
+    col = 1,
+    width = 20,
+    height = 1,
+  })
+end
+
+--- Run find_async inside an async task under the given `vim.ui.select` stub,
+--- returning { value = ... } once it resolves (or nil if it hangs).
+local function drive(ui_select_impl)
+  local saved = vim.ui.select
+  vim.ui.select = ui_select_impl
+
+  local outcome = nil
+  async.run(function()
+    local f = Finder.create({}):add_entries { "one", "two", "three" }
+    outcome = { value = f:find_async() }
+  end)
+
+  local resolved = wait_for(function()
+    return outcome ~= nil
+  end)
+
+  vim.ui.select = saved
+  return resolved and outcome or nil
+end
+
+describe("lib.finder", function()
+  local saved_check_integration
+
+  before_each(function()
+    saved_check_integration = config.check_integration
+    -- Force the vim.ui.select fallback branch: CI has telescope on the
+    -- runtimepath, so without this stub the finder would take the telescope
+    -- branch instead.
+    config.check_integration = function()
+      return false
+    end
+  end)
+
+  after_each(function()
+    config.check_integration = saved_check_integration
+  end)
+
+  describe("find_async", function()
+    -- Regression: some vim.ui.select replacements only invoke their callback via
+    -- their own confirm/cancel actions and skip it when the prompt window is
+    -- closed another way. A dropped callback used to park the awaiting
+    -- coroutine forever, wedging the shared popup action lock until restart.
+    it("resumes as abort when the select prompt window closes without a callback", function()
+      local outcome = drive(function(_, _opts, _on_choice)
+        local win = open_float()
+        vim.defer_fn(function()
+          if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true) -- closed, no callback
+          end
+        end, 30)
+      end)
+
+      assert.is_truthy(outcome) -- did not hang
+      assert.is_nil(outcome.value)
+    end)
+
+    it("delivers the real selection even if the window closes right after", function()
+      local outcome = drive(function(_, _opts, on_choice)
+        local win = open_float()
+        vim.defer_fn(function()
+          on_choice("two") -- implementations call on_choice before closing
+          if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true)
+          end
+        end, 30)
+      end)
+
+      assert.is_truthy(outcome)
+      assert.are.equal("two", outcome.value)
+    end)
+
+    it("returns nil on an explicit cancel", function()
+      local outcome = drive(function(_, _opts, on_choice)
+        on_choice(nil) -- no window at all
+      end)
+
+      assert.is_truthy(outcome)
+      assert.is_nil(outcome.value)
+    end)
+
+    it("delivers a synchronous selection", function()
+      local outcome = drive(function(_, _opts, on_choice)
+        on_choice("three") -- no window at all
+      end)
+
+      assert.is_truthy(outcome)
+      assert.are.equal("three", outcome.value)
+    end)
+  end)
+end)

--- a/tests/specs/neogit/lib/input_spec.lua
+++ b/tests/specs/neogit/lib/input_spec.lua
@@ -1,0 +1,100 @@
+local input = require("neogit.lib.input")
+local async = require("neogit.lib.async")
+
+--- Drives the event loop until `predicate()` returns true (or `timeout` ms elapse).
+local function wait_for(predicate, timeout)
+  return vim.wait(timeout or 1000, predicate, 5)
+end
+
+--- Open and enter a floating window, mimicking a `vim.ui.input` replacement
+--- (e.g. snacks.nvim) that synchronously enters its prompt window.
+local function open_float()
+  local buf = vim.api.nvim_create_buf(false, true)
+  return vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    row = 1,
+    col = 1,
+    width = 20,
+    height = 1,
+  })
+end
+
+--- Run get_user_input inside an async task under the given `vim.ui.input`
+--- stub, returning { value = ... } once it resolves (or nil if it hangs).
+local function drive(ui_input_impl)
+  local saved = vim.ui.input
+  vim.ui.input = ui_input_impl
+
+  local outcome = nil
+  async.run(function()
+    outcome = { value = input.get_user_input("Prompt") }
+  end)
+
+  local resolved = wait_for(function()
+    return outcome ~= nil
+  end)
+
+  vim.ui.input = saved
+  return resolved and outcome or nil
+end
+
+describe("lib.input", function()
+  describe("get_user_input", function()
+    -- Regression: some vim.ui.input replacements only invoke on_confirm via
+    -- their own confirm/cancel actions and skip it when the prompt window is
+    -- closed another way. A dropped callback used to park the awaiting
+    -- coroutine forever, wedging the shared popup action lock until restart.
+    it("resumes as a cancel when the prompt window closes without a callback", function()
+      local outcome = drive(function(_, _on_confirm)
+        local win = open_float()
+        vim.defer_fn(function()
+          if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true) -- closed, no callback
+          end
+        end, 30)
+      end)
+
+      assert.is_truthy(outcome) -- did not hang
+      assert.is_nil(outcome.value)
+    end)
+
+    it("delivers the real value even if the window closes right after", function()
+      local outcome = drive(function(_, on_confirm)
+        local win = open_float()
+        vim.defer_fn(function()
+          on_confirm("hello") -- implementations call on_confirm before closing
+          if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true)
+          end
+        end, 30)
+      end)
+
+      assert.is_truthy(outcome)
+      assert.are.equal("hello", outcome.value)
+    end)
+
+    it("returns nil on an explicit cancel without double-resuming", function()
+      local outcome = drive(function(_, on_confirm)
+        local win = open_float()
+        vim.defer_fn(function()
+          on_confirm(nil)
+          if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true)
+          end
+        end, 30)
+      end)
+
+      assert.is_truthy(outcome)
+      assert.is_nil(outcome.value)
+    end)
+
+    it("works with a synchronous cmdline-style implementation", function()
+      local outcome = drive(function(_, on_confirm)
+        on_confirm("typed") -- no window at all
+      end)
+
+      assert.is_truthy(outcome)
+      assert.are.equal("typed", outcome.value)
+    end)
+  end)
+end)

--- a/tests/specs/neogit/lib/process_spec.lua
+++ b/tests/specs/neogit/lib/process_spec.lua
@@ -1,0 +1,67 @@
+local Process = require("neogit.process")
+local async = require("neogit.lib.async")
+
+--- Drives the event loop until `predicate()` returns true (or `timeout` ms elapse).
+local function wait_for(predicate, timeout)
+  return vim.wait(timeout or 2000, predicate, 5)
+end
+
+describe("process", function()
+  describe("on_exit resilience", function()
+    -- Regression: on_exit runs presentation logic (error display, console
+    -- show/close) *before* invoking the resume callback. If any of it threw, the
+    -- callback was skipped and the awaiting coroutine was orphaned -- and because
+    -- popup actions hold a shared permit lock across the await, that silently
+    -- wedged every subsequent popup action until Neovim restarted.
+    it("still resumes the awaiting coroutine when on_error throws", function()
+      local outcome
+      async.run(function()
+        local proc = Process.new {
+          cmd = { "sh", "-c", "exit 1" }, -- non-zero exit -> triggers on_error
+          suppress_console = true,
+          on_error = function()
+            error("on-error-boom")
+          end,
+        }
+        outcome = { result = proc:spawn_async() }
+      end)
+
+      local resolved = wait_for(function()
+        return outcome ~= nil
+      end, 3000)
+
+      assert.is_truthy(resolved) -- did not hang
+      assert.is_truthy(outcome.result) -- got a ProcessResult back despite the throw
+      assert.are.equal(1, outcome.result.code)
+    end)
+
+    it("does not park the coroutine when the process fails to spawn", function()
+      -- Regression: on spawn failure the callback was dead code after `error()`,
+      -- so the awaiting coroutine was never resumed. The coroutine must always
+      -- unwind (resolve to nil per contract, or at worst re-raise) -- never park.
+      local outcome
+      async.run(function()
+        local proc = Process.new {
+          cmd = { "neogit-nonexistent-command-xyzzy" },
+          suppress_console = true,
+          on_error = function()
+            return true
+          end,
+        }
+        local ok, result = pcall(function()
+          return proc:spawn_async()
+        end)
+        outcome = { ok = ok, result = result }
+      end)
+
+      local resolved = wait_for(function()
+        return outcome ~= nil
+      end, 3000)
+
+      assert.is_truthy(resolved) -- did not hang
+      if outcome.ok then
+        assert.is_nil(outcome.result) -- spawn failure resolves to nil per contract
+      end
+    end)
+  end)
+end)


### PR DESCRIPTION
Some vim.ui.input implementations (e.g. snacks.nvim) only invoke on_confirm via their own confirm/cancel actions and skip it entirely when the prompt window is dismissed another way (:q, <C-w>c, a focus steal, a programmatic close). A dropped callback parked the awaiting coroutine forever -- and because popup actions run under a single shared permit lock (popup M.__lock), one parked action silently turned every subsequent popup action into a no-op until Neovim was restarted.

Harden the async input wrapper to guarantee its callback fires exactly once: the real value if the user responds, or nil (a normal cancel) if the prompt's floating window closes first, via a one-shot WinClosed autocmd (deferred so a genuine value always wins the race). This releases the popup action permit on every path without changing the locking model.

Add a regression spec covering stray-close-as-cancel, value-wins-race, explicit-cancel, and a synchronous cmdline-style implementation.