### PR TITLE
fix(finder): handle abort in mini.pick integration

### DIFF
--- a/lua/neogit/lib/finder.lua
+++ b/lua/neogit/lib/finder.lua
@@ -217,6 +217,39 @@ local function snacks_confirm(on_select, allow_multi, refocus_status)
   return confirm, on_close
 end
 
+--- Build `source.choose` and an abort handler for mini.pick
+---
+--- Unlike the confirm path, `source.choose` is not invoked when the picker is
+--- aborted (e.g. <Esc>); the caller wires the returned `on_stop` to a
+--- `MiniPickStop` autocmd so an abort still completes the finder via `nil`,
+--- matching the abort semantics of every other integration.
+---@param on_select fun(item: any|nil)
+---@param refocus_status boolean
+---@return function choose, function on_stop
+local function mini_pick_choose(on_select, refocus_status)
+  local completed = false
+  local function complete(selection)
+    if completed then
+      return
+    end
+    on_select(selection)
+    completed = true
+    if refocus_status then
+      refocus_status_buffer()
+    end
+  end
+
+  local function choose(item)
+    complete(item)
+  end
+
+  local function on_stop()
+    complete(nil)
+  end
+
+  return choose, on_stop
+end
+
 --- Utility function to map finder opts to fzf
 ---@param opts FinderOpts
 ---@return table
@@ -347,7 +380,22 @@ function Finder:find(on_select)
     })
   elseif config.check_integration("mini_pick") then
     local mini_pick = require("mini.pick")
-    mini_pick.start { source = { items = self.entries, choose = on_select } }
+    local choose, on_stop = mini_pick_choose(on_select, self.opts.refocus_status)
+    -- `source.choose` only fires on explicit confirm (<CR>); aborting via <Esc> goes
+    -- through `picker_stop` and never calls `choose`. Without the `MiniPickStop`
+    -- handler below, `on_select` would never run on abort, leaving the `find_async`
+    -- coroutine suspended forever (the picker then appears dead until restart).
+    local group = vim.api.nvim_create_augroup("NeogitMiniPickStop", { clear = true })
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "MiniPickStop",
+      once = true,
+      group = group,
+      callback = function()
+        vim.api.nvim_clear_autocmds { group = group }
+        on_stop()
+      end,
+    })
+    mini_pick.start { source = { items = self.entries, choose = choose } }
   elseif config.check_integration("snacks") then
     local snacks_picker = require("snacks.picker")
     local confirm, on_close = snacks_confirm(on_select, self.opts.allow_multi, self.opts.refocus_status)


### PR DESCRIPTION
## Problem

When `mini_pick` is enabled as the finder integration, aborting a selection (e.g. pressing `<Esc>` in the branch picker opened via `bb`) leaves the `find_async` coroutine **suspended forever**. The picker then appears dead — subsequent `bb` invocations show nothing until Neovim is restarted.

## Root cause

`Finder:find` documents its contract as (finder.lua:307-308):

```lua
---Engages finder and invokes `on_select` with the item or items, or nil if aborted
```

Every integration branch honors this — `on_select(nil)` is called on abort — **except `mini_pick`**:

```lua
elseif config.check_integration("mini_pick") then
  local mini_pick = require("mini.pick")
  mini_pick.start { source = { items = self.entries, choose = on_select } }  -- ← no abort path
end
```

`mini.pick`'s `source.choose` only fires on explicit confirm (`<CR>`). Aborting via `<Esc>` goes through `picker_stop`, which **never calls `choose`**. As a result `on_select` is never invoked on abort.

Since `Finder.find_async = a.wrap(Finder.find, 2)`, callers using `open_async` (e.g. `checkout_branch_revision` via `bb`) \`coroutine.yield\` waiting for `on_select` to resume them. With `on_select` never firing, the coroutine is permanently suspended.

Compare with how the other integrations handle abort:

| Integration | abort → `on_select(nil)` |
|---|---|
| `vim.ui.select` | calls `on_select(...)` with a nil item |
| `fzf_lua` | `["esc"]` / `["ctrl-c"]` / `["ctrl-q"]` → `close_action` → `on_select(nil)` |
| `telescope` | close → `on_select(nil)` |
| `snacks` | `on_close` → `complete(nil)` → `on_select(nil)` |
| **`mini_pick`** | **❌ none** |

## Fix

Wire a one-shot `MiniPickStop` autocmd (mini.pick has no `source.on_close` field) so an abort still completes the finder via `on_select(nil)`. The new `mini_pick_choose` helper mirrors the existing `snacks_confirm`, including the `completed` guard that ensures `on_select` runs exactly once.

```lua
elseif config.check_integration("mini_pick") then
  local mini_pick = require("mini.pick")
  local choose, on_stop = mini_pick_choose(on_select, self.opts.refocus_status)
  local group = vim.api.nvim_create_augroup("NeogitMiniPickStop", { clear = true })
  vim.api.nvim_create_autocmd("User", {
    pattern = "MiniPickStop", once = true, group = group,
    callback = function()
      vim.api.nvim_clear_autocmds { group = group }
      on_stop()
    end,
  })
  mini_pick.start { source = { items = self.entries, choose = choose } }
end
```

## Reproduce

1. `setup({ integrations = { mini_pick = true } })`
2. Open neogit status, press `bb` (branch/revision checkout)
3. Press `<Esc>` instead of `<CR>`
4. Press `bb` again — picker no longer opens; requires restarting Neovim to recover