### PR TITLE
fix: binary file rename changes in commit view

### DIFF
--- a/lua/neogit/buffers/commit_view/parsing.lua
+++ b/lua/neogit/buffers/commit_view/parsing.lua
@@ -22,6 +22,10 @@ function M.parse_commit_overview(raw)
         -- matches: .../db/b8571c4f873daff059c04443077b43a703338a      | Bin 0 -> 192 bytes
         file.path, file.changes = raw[i]:match(" (.*)%s+|%s+(Bin .*)$")
       end
+      if vim.tbl_isempty(file) then
+        -- matches:  resource/{ => audio}/error.wav                     | Bin
+        file.path, file.changes = raw[i]:match(" (.*)%s+|%s+(Bin)$")
+      end
 
       table.insert(overview.files, file)
     end


### PR DESCRIPTION
Closes #1884.

Potential Issues:
- Current commit parser directly puts path containing `{ => newname}` into `file.path`; not sure if it will break something or not. Though I ran all the tests and it seems nothing is broken but I'm not sure.