### PR TITLE
feat: cleanup buffers after loading a session

### DIFF
--- a/lua/neogit/autocmds.lua
+++ b/lua/neogit/autocmds.lua
@@ -18,6 +18,17 @@ function M.setup()
     group = group,
   })
 
+  api.nvim_create_autocmd("SessionLoadPost", {
+    callback = function()
+      for _, buf in ipairs(api.nvim_list_bufs()) do
+        local buf_name = api.nvim_buf_get_name(buf)
+        if buf_name:match("Neogit%w+") then
+          api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end,
+  })
+
   local autocmd_disabled = false
   api.nvim_create_autocmd({ "BufWritePost", "ShellCmdPost", "VimResume" }, {
     callback = a.void(function(o)


### PR DESCRIPTION
Context: https://github.com/neovim/neovim/issues/40336

TLDR: Neogit leaves leftover buffers when restoring vim sessions. We could have a "full restore" functionality, but that's somewhat complex. Instead, just wipe the leftover buffers, which is a low-cost improvement.